### PR TITLE
fix(styles): select component background

### DIFF
--- a/libs/styles/src/lib/scss/components/_select.scss
+++ b/libs/styles/src/lib/scss/components/_select.scss
@@ -61,8 +61,7 @@
     #{$base}__input {
       // TODO: consider moving these reset styles to _reset.scss
       box-sizing: content-box;
-      /* stylelint-disable-next-line declaration-property-value-allowed-list */
-      background-color: none;
+      background: none;
       border: none;
       box-shadow: none;
       outline: none;


### PR DESCRIPTION
input element background hides the placeholder, remove the backround to display everything as expected