### PR TITLE
feat(ng): custom gap prop to cvi-ng-labeled-icon

### DIFF
--- a/libs/ui/src/lib/button/button.component.stories.ts
+++ b/libs/ui/src/lib/button/button.component.stories.ts
@@ -1,7 +1,6 @@
-import { Story, Meta, ArgTypes } from '@storybook/angular';
+import { Story, Meta } from '@storybook/angular';
 import notes from './button.component.md';
 import { ButtonComponent } from './button.component';
-import { iconSizeDefault } from '../icons/icon/icon';
 
 export default {
   title: 'Angular/Button',
@@ -61,27 +60,11 @@ const TemplateTextButtonWithIcon: Story<ButtonComponent> = (
   /* template */
   template: `
     <cvi-ng-button appearance="text">
-      <cvi-ng-labeled-icon name="add" iconPosition="before" alignment="center" [iconHeight]="iconHeight">
+      <cvi-ng-labeled-icon name="add" iconPosition="before" verticalAlignment="center" [iconHeight]="16">
         {{ content }}
       </cvi-ng-labeled-icon>
     </cvi-ng-button>
   `,
 });
 
-type TextButtonWithIconWithCustomArgs = ButtonComponent & {
-  iconHeight: number;
-};
-
 export const TextButtonWithIcon = TemplateTextButtonWithIcon.bind({});
-TextButtonWithIcon.argTypes = {
-  iconHeight: {
-    name: 'Icon height',
-    table: {
-      category: 'Playground',
-    },
-  },
-} as Partial<ArgTypes<TextButtonWithIconWithCustomArgs>>;
-TextButtonWithIcon.args = {
-  appearance: 'text',
-  iconHeight: iconSizeDefault,
-} as TextButtonWithIconWithCustomArgs;

--- a/libs/ui/src/lib/button/button.component.stories.ts
+++ b/libs/ui/src/lib/button/button.component.stories.ts
@@ -60,7 +60,7 @@ const TemplateTextButtonWithIcon: Story<ButtonComponent> = (
   /* template */
   template: `
     <cvi-ng-button appearance="text">
-      <cvi-ng-labeled-icon name="add" iconPosition="before" verticalAlignment="center" [iconHeight]="16">
+      <cvi-ng-labeled-icon name="add" iconPosition="before" verticalAlignment="center" [iconHeight]="16" [gap]="2">
         {{ content }}
       </cvi-ng-labeled-icon>
     </cvi-ng-button>

--- a/libs/ui/src/lib/icons/labeled-icon/labeled-icon.component.html
+++ b/libs/ui/src/lib/icons/labeled-icon/labeled-icon.component.html
@@ -1,4 +1,4 @@
-<cvi-ng-track [gap]="4" [verticalAlignment]="verticalAlignment">
+<cvi-ng-track [gap]="gap" [verticalAlignment]="verticalAlignment">
   <ng-container *ngIf="iconPosition === 'before'">
     <ng-container *ngTemplateOutlet="icon"></ng-container>
   </ng-container>

--- a/libs/ui/src/lib/icons/labeled-icon/labeled-icon.component.stories.ts
+++ b/libs/ui/src/lib/icons/labeled-icon/labeled-icon.component.stories.ts
@@ -21,12 +21,17 @@ export default {
       },
       control: { type: 'text' },
     },
+    gap: {
+      name: 'Gap',
+      control: { type: 'range', min: 0, max: 20, step: 1 },
+    },
     svgClass: { control: false },
     iconClass: { control: false },
   },
   args: {
     iconHeight: iconSizeDefault,
     name: 'call',
+    gap: 4,
     iconPosition: 'before',
     content: 'This is a labeled icon',
   },
@@ -36,7 +41,7 @@ const Template: Story<LabeledIconComponent> = (args: LabeledIconComponent) => ({
   props: args,
   /* template */
   template: `
-    <cvi-ng-labeled-icon [name]="name" [iconPosition]="iconPosition" [verticalAlignment]="verticalAlignment" [iconHeight]="iconHeight">
+    <cvi-ng-labeled-icon [name]="name" [iconPosition]="iconPosition" [verticalAlignment]="verticalAlignment" [iconHeight]="iconHeight" [gap]="gap">
       {{ content }}
     </cvi-ng-labeled-icon>
   `,
@@ -46,6 +51,9 @@ export const Default = Template.bind({});
 
 export const WithIconAfter = Template.bind({});
 WithIconAfter.args = { iconPosition: 'after' };
+
+export const WithCustomGap = Template.bind({});
+WithCustomGap.args = { gap: 2 };
 
 const TemplateInsideButton: Story<LabeledIconComponent> = (
   args: LabeledIconComponent

--- a/libs/ui/src/lib/icons/labeled-icon/labeled-icon.component.ts
+++ b/libs/ui/src/lib/icons/labeled-icon/labeled-icon.component.ts
@@ -7,6 +7,7 @@ import {
   ViewChild,
 } from '@angular/core';
 import { CviIconName } from '@egov/cvi-icons';
+import { Gap } from '../../track/track';
 import { iconSizeDefault } from '../icon/icon';
 import { LabeledIconPosition } from './icon-position';
 import { LabeledIconVerticalAlignment } from './vertical-alignment';
@@ -29,6 +30,10 @@ export class LabeledIconComponent {
   /** Icon height in px */
   @Input()
   iconHeight?: number = iconSizeDefault;
+
+  /** Gap between icon and text */
+  @Input()
+  gap: Gap = 4;
 
   /** Additional classes for the cvi-ng-icon element */
   @Input() iconClass = 'cvi-labeled-icon__icon-wrapper';

--- a/libs/ui/src/lib/icons/labeled-icon/labeled-icon.component.ts
+++ b/libs/ui/src/lib/icons/labeled-icon/labeled-icon.component.ts
@@ -30,7 +30,7 @@ export class LabeledIconComponent {
   @Input()
   iconHeight?: number = iconSizeDefault;
 
-  /** Additional classes for the cvi-ng-icon element. You can set icon height here */
+  /** Additional classes for the cvi-ng-icon element */
   @Input() iconClass = 'cvi-labeled-icon__icon-wrapper';
 
   @Input() verticalAlignment: LabeledIconVerticalAlignment = 'normal';


### PR DESCRIPTION
`cvi-ng-labeled-icon` may be used to create toolbar buttons with icons, as indicated in an example in Angular/Button/Text Button With Icon story. The only thing missing in this solution to correspond to reference designs is a gap which was hardcoded to have value of `4`. Now it can be customised. 