### PR TITLE
fix(styles): fixed consumer app sass import error relative to project root

### DIFF
--- a/libs/styles/README.md
+++ b/libs/styles/README.md
@@ -2,6 +2,10 @@
 
 This library was generated with [Nx](https://nx.dev).
 
+## File paths
+
+With `@use`, `@import`, or `@forward` at-rules use paths relative to the file. Eg. instead of `@use 'libs/styles/src/lib/scss/settings/variables/colors';` employ `@use '../settings/variables/colors';`. Otherwise a consumer app compilation might break.
+
 ## Running unit tests
 
 Run `nx test styles` to execute the unit tests via [Jest](https://jestjs.io).

--- a/libs/styles/src/lib/scss/tools/_color.scss
+++ b/libs/styles/src/lib/scss/tools/_color.scss
@@ -1,5 +1,5 @@
 @use 'sass:map';
-@use 'libs/styles/src/lib/scss/settings/variables/colors';
+@use '../settings/variables/colors';
 
 // Returns variable as a CSS variable
 @function get-color($color-name) {

--- a/libs/styles/src/lib/scss/tools/_typography.scss
+++ b/libs/styles/src/lib/scss/tools/_typography.scss
@@ -1,5 +1,5 @@
 @use 'sass:map';
-@use 'libs/styles/src/lib/scss/settings/variables/typography';
+@use '../settings/variables/typography';
 
 @function get-font-size($font-size, $return-value: false) {
   @if map.has-key(typography.$cvi-font-sizes, $font-size) {


### PR DESCRIPTION
Fixed an issue introduced in 1.5 where a consumer app compilation would break with "Can't find a stylesheet to import" error.