### PR TITLE
ci(test): added automatic screenshot testing via Chromatic CI

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -11,3 +11,5 @@ jobs:
         run: npm ci
       - name: Publish to Chromatic
         uses: chromaui/action@v1
+        with:
+          projectToken: 23c52c9242eb

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -8,11 +8,8 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Install dependencies
-        run: npm
-        # 👇 Adds Chromatic as a step in the workflow
+        run: npm ci
       - name: Publish to Chromatic
         uses: chromaui/action@v1
-        # Chromatic GitHub Action options
         with:
-          # 👇 Chromatic projectToken, refer to the manage page to obtain it.
           projectToken: 23c52c9242eb

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,0 +1,18 @@
+name: 'Chromatic'
+
+on: push
+
+jobs:
+  chromatic-deployment:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Install dependencies
+        run: npm
+        # 👇 Adds Chromatic as a step in the workflow
+      - name: Publish to Chromatic
+        uses: chromaui/action@v1
+        # Chromatic GitHub Action options
+        with:
+          # 👇 Chromatic projectToken, refer to the manage page to obtain it.
+          projectToken: 23c52c9242eb

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -22,4 +22,5 @@ jobs:
         uses: chromaui/action@v1
         with:
           projectToken: 23c52c9242eb
+          skip: '@(test-**|dependabot/**)'
           onlyChanged: true

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -6,7 +6,16 @@ jobs:
   chromatic-deployment:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: 'npm'
+
       - name: Install dependencies
         run: npm ci
       - name: Publish to Chromatic

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -13,3 +13,4 @@ jobs:
         uses: chromaui/action@v1
         with:
           projectToken: 23c52c9242eb
+          onlyChanged: true

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -11,5 +11,3 @@ jobs:
         run: npm ci
       - name: Publish to Chromatic
         uses: chromaui/action@v1
-        with:
-          projectToken: 23c52c9242eb

--- a/README.md
+++ b/README.md
@@ -82,3 +82,9 @@ Run `nx graph` to see a diagram of the dependencies of your projects.
 Storybook needs to be up and running as Cypress tests are using its Angular components in iFrame windows. Check previous chapter about 'Running the Storybook'.
 
 When storybook is up and running, run `npm run cy:ui` which opens up Cypress visual testing tool. Select E2E Testing, which presents you all components tests.
+
+## Thanks
+
+<a href="https://www.chromatic.com/"><img src="https://user-images.githubusercontent.com/321738/84662277-e3db4f80-af1b-11ea-88f5-91d67a5e59f6.png" width="153" height="30" alt="Chromatic" /></a>
+
+Thanks to [Chromatic](https://www.chromatic.com/) for providing the visual testing platform that helps us review UI changes and catch visual regressions.

--- a/README.md
+++ b/README.md
@@ -83,6 +83,14 @@ Storybook needs to be up and running as Cypress tests are using its Angular comp
 
 When storybook is up and running, run `npm run cy:ui` which opens up Cypress visual testing tool. Select E2E Testing, which presents you all components tests.
 
+## Running Chromatic tests
+
+The project uses automatic screenshot testing via Chromatic. Run `npm run chromatic`, open the resulting URL and go through the visual changes, accepting or denying them in the Chromatic UI.
+
+Chromatic CI also runs on every push. The action always passes (even when visual changes are detected) except for cases when a story is broken. Contributors and reviewers should check the results of the action (and accept or decline them in the Chromatic UI) by following a link in the build log.
+
+Publishing to Chromatic also gives a possibility to share a Storybook link for a specific branch (even unpushed, if the local npm command is used) in this format `https://<branch>--6373995e3f280e239470296d.chromatic.com`.
+
 ## Thanks
 
 <a href="https://www.chromatic.com/"><img src="https://user-images.githubusercontent.com/321738/84662277-e3db4f80-af1b-11ea-88f5-91d67a5e59f6.png" width="153" height="30" alt="Chromatic" /></a>

--- a/apps/ui-e2e/src/component/track.component.cy.ts
+++ b/apps/ui-e2e/src/component/track.component.cy.ts
@@ -4,7 +4,7 @@ describe('TrackComponent', () => {
   });
 
   it('Renders track with correct gap', () => {
-    cy.loadStory('Angular Track', 'Default')
+    cy.loadStory('Angular Track Stories', 'Default')
       .get('cvi-ng-track')
       .changeArg('gap', 2);
 
@@ -12,7 +12,7 @@ describe('TrackComponent', () => {
   });
 
   it('Renders track with correct horizontal alignment', () => {
-    cy.loadStory('Angular Track', 'Default')
+    cy.loadStory('Angular Track Stories', 'Default')
       .get('cvi-ng-track')
       .changeArg('horizontalAlignment', 'center');
 
@@ -20,7 +20,7 @@ describe('TrackComponent', () => {
   });
 
   it('Renders track with correct vertical alignment', () => {
-    cy.loadStory('Angular Track', 'Default')
+    cy.loadStory('Angular Track Stories', 'Default')
       .get('cvi-ng-track')
       .changeArg('verticalAlignment', 'bottom');
 
@@ -28,7 +28,7 @@ describe('TrackComponent', () => {
   });
 
   it('Renders track with correct multiline setting', () => {
-    cy.loadStory('Angular Track', 'Default')
+    cy.loadStory('Angular Track Stories', 'Default')
       .get('cvi-ng-track')
       .changeArg('flexIsMultiline', true);
 
@@ -36,7 +36,7 @@ describe('TrackComponent', () => {
   });
 
   it('Renders track with correct layout', () => {
-    cy.loadStory('Angular Track', 'Default')
+    cy.loadStory('Angular Track Stories', 'Default')
       .get('cvi-ng-track')
       .changeArg('layout', 'grid');
 

--- a/libs/storybook/.storybook/sorting-order.json
+++ b/libs/storybook/.storybook/sorting-order.json
@@ -40,6 +40,7 @@
     [
       "Installation",
       "Track",
+      ["Quick start", "Stories"],
       "Screenreader text",
       "Content container",
       "Content panel",

--- a/libs/storybook/src/lib/stories/angular.stories.mdx
+++ b/libs/storybook/src/lib/stories/angular.stories.mdx
@@ -1,7 +1,10 @@
 import {Meta, Story} from '@storybook/addon-docs';
 import uiPkg from '/libs/ui/package.json'
 
-<Meta title="Angular/Installation" parameters={{viewMode: 'docs'}}/>
+<Meta title="Angular/Installation" parameters={{
+  viewMode: 'docs',
+  chromatic: { disableSnapshot: true },
+}}/>
 
 # How to Install the Angular UI Kit
 

--- a/libs/storybook/src/lib/stories/intro.stories.mdx
+++ b/libs/storybook/src/lib/stories/intro.stories.mdx
@@ -3,7 +3,10 @@ import stylesPkg from '/libs/styles/package.json';
 import iconsPkg from '/libs/icons/package.json'
 import uiPkg from '/libs/ui/package.json'
 
-<Meta title="Intro" parameters={{viewMode: 'docs'}}/>
+<Meta title="Intro" parameters={{
+  viewMode: 'docs',
+  chromatic: { disableSnapshot: true },
+}}/>
 
 # Welcome to the e-Gov CVI UI library!
 

--- a/libs/storybook/src/lib/stories/styles/contributions.stories.mdx
+++ b/libs/storybook/src/lib/stories/styles/contributions.stories.mdx
@@ -1,6 +1,10 @@
 import { Meta, Story } from '@storybook/addon-docs';
 
-<Meta title="Styles/How to contribute" parameters={{ viewMode: 'docs', layout: 'fullscreen' }} />
+<Meta title="Styles/How to contribute" parameters={{
+  viewMode: 'docs',
+  layout: 'fullscreen',
+  chromatic: { disableSnapshot: true },
+}} />
 
 # How to contribute to the library styles
 

--- a/libs/storybook/src/lib/stories/styles/installation.stories.mdx
+++ b/libs/storybook/src/lib/stories/styles/installation.stories.mdx
@@ -3,7 +3,10 @@ import stylesPkg from '/libs/styles/package.json';
 
 # How to Install CVI Styles
 
-<Meta title="Styles/How to install" parameters={{viewMode: 'docs'}}/>
+<Meta title="Styles/How to install" parameters={{
+  viewMode: 'docs',
+  chromatic: { disableSnapshot: true },
+}}/>
 
 <Story name="How to install">
   {{

--- a/libs/storybook/src/lib/stories/styles/usage.stories.mdx
+++ b/libs/storybook/src/lib/stories/styles/usage.stories.mdx
@@ -1,6 +1,10 @@
 import { Meta, Story } from '@storybook/addon-docs';
 
-<Meta title="Styles/How to use" parameters={{ viewMode: 'docs', layout: 'fullscreen' }} />
+<Meta title="Styles/How to use" parameters={{
+  viewMode: 'docs',
+  layout: 'fullscreen',
+  chromatic: { disableSnapshot: true },
+}} />
 
 # Using the library styles
 

--- a/libs/storybook/src/lib/stories/styles/variables/variables.stories.mdx
+++ b/libs/storybook/src/lib/stories/styles/variables/variables.stories.mdx
@@ -1,6 +1,10 @@
 import { Meta, Story } from '@storybook/addon-docs';
 
-<Meta title="Styles/Available variables/Overview" parameters={{ viewMode: 'docs', layout: 'fullscreen' }} />
+<Meta title="Styles/Available variables/Overview" parameters={{
+  viewMode: 'docs',
+  layout: 'fullscreen',
+  chromatic: { disableSnapshot: true },
+}} />
 
 # Variables overview
 

--- a/libs/storybook/src/lib/stories/todos.stories.mdx
+++ b/libs/storybook/src/lib/stories/todos.stories.mdx
@@ -1,6 +1,10 @@
 import {Meta} from '@storybook/addon-docs';
 
-<Meta title="TODOS" parameters={{viewMode: 'docs', layout: 'fullscreen'}}/>
+<Meta title="TODOS" parameters={{
+  viewMode: 'docs',
+  layout: 'fullscreen',
+  chromatic: { disableSnapshot: true },
+}}/>
 
 # TODOS
 

--- a/libs/ui/src/lib/form-item/form-item.component.stories.ts
+++ b/libs/ui/src/lib/form-item/form-item.component.stories.ts
@@ -31,7 +31,7 @@ const Template: Story<FormItemComponent> = (args: FormItemComponent) => ({
 
 export const Default = Template.bind({});
 
-const TextareaTemplate: Story<FormItemComponent> = (
+const WithTextareaTemplate: Story<FormItemComponent> = (
   args: FormItemComponent
 ) => ({
   props: args,
@@ -49,4 +49,7 @@ const TextareaTemplate: Story<FormItemComponent> = (
   `,
 });
 
-export const WithTextarea = TextareaTemplate.bind({});
+export const WithTextarea = WithTextareaTemplate.bind({});
+WithTextarea.parameters = {
+  chromatic: { disableSnapshot: true },
+};

--- a/libs/ui/src/lib/reorderable-list/reorderable-list/reorderable-list.component.stories.ts
+++ b/libs/ui/src/lib/reorderable-list/reorderable-list/reorderable-list.component.stories.ts
@@ -215,4 +215,7 @@ export const ReorderableListMultipleTracksAndFormItems =
   ReorderableListMultipleTracksAndFormItemsTemplate.bind({});
 ReorderableListMultipleTracksAndFormItems.storyName =
   'Multiple tracks with multiple form items, and a standalone form item';
-ReorderableListMultipleTracksAndFormItems.args = {};
+ReorderableListMultipleTracksAndFormItems.parameters = {
+  // Disabling Chromatic because cvi-ng-textarea triggers a visual change on every build
+  chromatic: { disableSnapshot: true },
+};

--- a/libs/ui/src/lib/select/select.component.stories.ts
+++ b/libs/ui/src/lib/select/select.component.stories.ts
@@ -35,7 +35,7 @@ export default {
     ],
     placeholder: 'Otsi elementi',
     disabled: false,
-    containerWidth: 200,
+    containerWidth: 220,
   },
 } as Meta;
 

--- a/libs/ui/src/lib/select/select.component.stories.ts
+++ b/libs/ui/src/lib/select/select.component.stories.ts
@@ -17,6 +17,15 @@ export default {
     }),
   ],
   parameters: { notes },
+  argTypes: {
+    containerWidth: {
+      name: 'Container width',
+      table: {
+        category: 'Playground',
+      },
+      control: { type: 'number' },
+    },
+  },
   args: {
     items: [
       'valik 1',
@@ -26,6 +35,7 @@ export default {
     ],
     placeholder: 'Otsi elementi',
     disabled: false,
+    containerWidth: 200,
   },
 } as Meta;
 
@@ -35,7 +45,7 @@ const Template: Story<SelectComponent> = (args: SelectComponent) => ({
   },
   /* template */
   template: `
-      <div style="width: 200px">
+      <div [ngStyle]="{'width.px': containerWidth}">
         <cvi-ng-select [items]="items"
                        [disabled]="disabled"
                        [placeholder]="placeholder"></cvi-ng-select>
@@ -58,7 +68,7 @@ const UserCanAddItemsTemplate: Story<SelectComponent> = (
     },
     /* template */
     template: `
-      <div style="width: 200px">
+      <div [ngStyle]="{'width.px': containerWidth}">
         <cvi-ng-select [items]="items"
                        [addItemFn]="addItemFn"
                        [addItemLabel]="'Lisa element'"
@@ -77,7 +87,7 @@ const DisabledBackgroundTemplate: Story<SelectComponent> = (
   },
   /* template */
   template: `
-      <div style="width: 200px">
+      <div [ngStyle]="{'width.px': containerWidth}">
         <cvi-ng-select [items]="items"
                        [backgroundDisabled]="true"
                        [placeholder]="placeholder"></cvi-ng-select>
@@ -94,7 +104,7 @@ const ObjectsAsItemsTemplate: Story<SelectComponent> = (
   },
   /* template */
   template: `
-      <div style="width: 200px">
+      <div [ngStyle]="{'width.px': containerWidth}">
         <cvi-ng-select [items]="items"
                          [placeholder]="placeholder"
                          [searchFn]="searchFn">
@@ -131,7 +141,7 @@ const DisabledTemplate: Story<SelectComponent> = (args: SelectComponent) => ({
   },
   /* template */
   template: `
-      <div style="width: 200px">
+      <div [ngStyle]="{'width.px': containerWidth}">
         <cvi-ng-select [items]="items"
                        [disabled]="disabled"
                        [placeholder]="placeholder"></cvi-ng-select>
@@ -160,7 +170,7 @@ const FormTemplate: Story<SelectComponent> = (args: SelectComponent) => {
     },
     /* template */
     template: `
-      <div style="width: 200px" [formGroup]="form">
+      <div [ngStyle]="{'width.px': containerWidth}" [formGroup]="form">
         <cvi-ng-select [items]="items" formControlName="item" [placeholder]="placeholder"></cvi-ng-select>
         <div>Selected value: {{selectedValue()}}</div>
       </div>

--- a/libs/ui/src/lib/steps/steps/steps.component.stories.ts
+++ b/libs/ui/src/lib/steps/steps/steps.component.stories.ts
@@ -3,6 +3,8 @@ import notes from './steps.component.md';
 import { concatMap, delay, from, of } from 'rxjs';
 import { StepsComponent } from './steps.component';
 
+const withObservableTitlesDelay = 1000;
+
 export default {
   title: 'Angular/Steps/Steps',
   component: StepsComponent,
@@ -99,7 +101,7 @@ const TemplateObservableTitles: Story = (args) => ({
   props: {
     ...args,
     labels$: from([['First', 'Second', 'Third']]).pipe(
-      concatMap((item) => of(item).pipe(delay(1000)))
+      concatMap((item) => of(item).pipe(delay(withObservableTitlesDelay)))
     ),
   },
   /* template */
@@ -117,7 +119,9 @@ const TemplateObservableTitles: Story = (args) => ({
 });
 
 export const WithObservableTitles = TemplateObservableTitles.bind({});
-WithObservableTitles.args = {};
+WithObservableTitles.parameters = {
+  chromatic: { delay: withObservableTitlesDelay + 300 },
+};
 
 const TemplateWithTranslations: Story<StepsComponent> = (
   args: StepsComponent

--- a/libs/ui/src/lib/table-of-contents/generated-table-of-contents/generated-table-of-contents.component.stories.ts
+++ b/libs/ui/src/lib/table-of-contents/generated-table-of-contents/generated-table-of-contents.component.stories.ts
@@ -76,6 +76,8 @@ export default {
   parameters: {
     layout: 'padded',
     notes,
+    // disabling Chromatic because random text will trigger changes on each run
+    chromatic: { disableSnapshot: true },
   },
   decorators: [
     moduleMetadata({

--- a/libs/ui/src/lib/table-of-contents/table-of-contents-item/table-of-contents-item.component.stories.ts
+++ b/libs/ui/src/lib/table-of-contents/table-of-contents-item/table-of-contents-item.component.stories.ts
@@ -8,6 +8,8 @@ export default {
   parameters: {
     layout: 'padded',
     notes,
+    // disabling Chromatic because random text will trigger changes on each run
+    chromatic: { disableSnapshot: true },
   },
   args: {
     label: 'Section One with a very long label that spans many lines',

--- a/libs/ui/src/lib/table-of-contents/table-of-contents-wrapper/table-of-contents-wrapper.component.stories.ts
+++ b/libs/ui/src/lib/table-of-contents/table-of-contents-wrapper/table-of-contents-wrapper.component.stories.ts
@@ -8,6 +8,8 @@ export default {
   parameters: {
     layout: 'padded',
     notes,
+    // disabling Chromatic because random text will trigger changes on each run
+    chromatic: { disableSnapshot: true },
   },
 } as Meta;
 

--- a/libs/ui/src/lib/table-of-contents/table-of-contents/table-of-contents.component.stories.ts
+++ b/libs/ui/src/lib/table-of-contents/table-of-contents/table-of-contents.component.stories.ts
@@ -27,6 +27,160 @@ const Template: Story<TableOfContentsComponent> = (
       <div>
         <div cviNgToCSection="section-one">
           <h1>Section One</h1>
+          <p>This Pokemon is a ice-type Pokemon and looks a lot like an antelope. It has snowy legs, an icicle covered tail and frosty ears. They're generally playful by nature and can often be found in winter. If you're out looking for them they can often be seen lurking about and on their own. It tends to attack with Haze and Ice Punch. It hasn't evolved yet and there are no known evolutions.</p>
+          <p>It shall be then, when rocks will rain from the sky, a man clad in green shall bring forth a rise of faith.</p>
+          <p>It shall be then, when what is blue turns red, the false leader shall bring the toppling of leaders and the return of dragons.</p>
+          <p>Billy's first act on arriving in this sanctum was to release the cat, which, having moved restlessly about for some moments, finally came to the conclusion that there was no means of getting out, and settled itself on a corner of the settee. Psmith, sinking gracefully down beside it, stretched out his legs and lit a cigarette. Mike took one of the ordinary chairs; and Billy Windsor, planting himself in the rocker, began to rock rhythmically to and fro, a performance which he kept up untiringly all the time.</p>
+          <p>Once the true one reveals herself, a random act of kindness shall mark a strengthening of bonds.</p>
+          <p>This Pokemon is a poison-type Pokemon and looks a little like a caterpillar. It has phosphorescent skin, thin legs and a lack of a mouth. They're generally threatening by nature and can often be found in labyrinths. If you're out looking for them they can often be seen on their own. It tends to attack with Venoshock and Sludge. It hasn't evolved yet, but could do so twice.</p>
+          <p>This Pokemon is a psychic-type Pokemon and faintly looks like a mouse. It has a glowing snout, camouflaged fur and fat legs. They're generally timid by nature and can often be found near sanctuaries. If you're out looking for them they can often be seen on their own. It tends to attack with Trick Room and Lunar Dance. It hasn't evolved yet, but could do so once.</p>
+          <p>Once the true one reveals herself, a random act of kindness shall mark a strengthening of bonds.</p>
+          <p>When the brother becomes the father, a suspicious death shall bring forth bloodshed of blue blood and the return of monsters.</p>
+          <p>When the day comes that the day is shortest, three siblings shall usher forth bloodshed of blue blood.</p>
+          <p>The day kingdoms collide, a suspicious accident shall cause a time of peace and an age of failing crops.</p>
+          <p>When the day comes that the day is shortest, three siblings shall usher forth bloodshed of blue blood.</p>
+        </div>
+
+        <div cviNgToCSection="section-two">
+          <h1>Section Two</h1>
+          <p>Happily wall anything pleasant court made vegetable freedom printed plate education six longer anyway mill forty active manufacturing struggle darkness teach round further handle.</p>
+          <p>so image across automobile twenty how some fight earn fireplace elephant flow cat slightly factor free mighty most fox taken seldom rhyme especially upper.</p>
+        </div>
+
+        <div cviNgToCSection="section-three">
+          <h1>Section Three</h1>
+          <p> It shall be on the day that the world becomes shrouded in shadows, the
+            prophet shall bring an eternal night and a change of leadership.</p>
+          <p> It shall be on the day that steel turns to rust, two enemies shall cause
+            the toppling of leaders and the beginning of a better future.</p>
+          <p> The day kingdoms collide, a suspicious accident shall cause a time of
+            peace and an age of failing crops.</p>
+          <p>The day fire burns blue, the prophet shall cause an age of anarchy.</p>
+          <p>When the moment comes that one becomes many and many becomes one, a man
+            clad in green shall bring forth the dawn of evil and a time of peace.</p>
+          <p> The day the rain returns, a victory shall mark an end to hunger and the
+            end of wealth.</p>
+          <p> As soon as the sun turns dark, a sudden death shall cause a generation of
+            health and an age of misfortune.</p>
+          <p> It shall be then, when what is blue turns red, the false leader shall
+            bring the toppling of leaders and the return of dragons.</p>
+          <p> It shall be on the day that the world becomes shrouded in shadows, the
+            prophet shall bring an eternal night and a change of leadership.</p>
+          <p> This Pokemon is a psychic-type Pokemon and faintly looks like a mouse. It
+            has a glowing snout, camouflaged fur and fat legs. They're generally timid
+            by nature and can often be found near sanctuaries. If you're out looking
+            for them they can often be seen on their own. It tends to attack with
+            Trick Room and Lunar Dance. It hasn't evolved yet, but could do so once.</p>
+          <p> As soon as the sea swallows the earth, two brothers shall bring a rise of
+            faith.</p>
+          <p> As soon as the sea swallows the earth, two brothers shall bring a rise of
+            faith.</p>
+          <p> It shall be on the day that steel turns to rust, two enemies shall cause
+            the toppling of leaders and the beginning of a better future.</p>
+          <p> There comes a day when prey kills predator, the young one shall usher
+            forth a strengthening of bonds and new aggressions.</p>
+          <p> It shall be then, when what is blue turns red, the false leader shall
+            bring the toppling of leaders and the return of dragons.</p>
+          <p> This Pokemon is a ice-type Pokemon and looks a lot like a cod. It has
+            stubby fins, pure white scales and a cavernous mouth. They're generally
+            energetic by nature and can often be found during a blizzard. If you're
+            out looking for them they can often be seen among many other kinds of
+            Pokemon. It tends to attack with Ice Ball and Aurora Beam. It has evolved twice and can evolve no more. </p>
+        </div>
+
+        <div cviNgToCSection="section-four">
+          <h1>Section Four</h1>
+          <p> When the moment comes that the dead rise, the accused shall cause an age
+          of lawlessness.</p>
+          <p> This Pokemon is a ice-type Pokemon and looks a lot like an antelope. It
+            has snowy legs, an icicle covered tail and frosty ears. They're generally
+            playful by nature and can often be found in winter. If you're out looking
+            for them they can often be seen lurking about and on their own. It tends
+            to attack with Haze and Ice Punch. It hasn't evolved yet and there are no
+            known evolutions. </p>
+          <p> As soon as the sea swallows the earth, two brothers shall bring a rise of
+            faith. </p>
+          <p> There comes a day when mountains move and rivers shiver, a refusal shall
+            bring the end of leadership. </p>
+          <p> "Too decorous, Comrade Jackson. I came over here principally, it is true,
+            to be at your side, should you be in any way persecuted by scoundrels. But
+            at the same time I confess that at the back of my mind there lurked a hope
+            that stirring adventures might come my way. I had heard so much of the
+            place. Report had it that an earnest seeker after amusement might have a
+            tolerably spacious rag in this modern Byzantium. I thought that a few
+            weeks here might restore that keen edge to my nervous system which the
+            languor of the past term had in a measure blunted. I wished my visit to be
+            a tonic rather than a sedative. I anticipated that on my return the cry
+            would go round Cambridge, 'Psmith has been to New York. He is full of
+            oats. For he on honey-dew hath fed, and drunk the milk of Paradise. He is
+            hot stuff. Rah!' But what do we find?" </p>
+          <p> It shall be then, when rocks will rain from the sky, a man clad in green
+            shall bring forth a rise of faith. </p>
+          <p>The day fire burns blue, the prophet shall cause an age of anarchy.</p>
+          <p> By the time that Pugsy returned, carrying a five-cent bottle of milk, the
+            animal had vacated the book-shelf, and was sitting on the table, washing
+            her face. The milk having been poured into the lid of a tobacco-tin, in
+            lieu of a saucer, she suspended her operations and adjourned for
+            refreshments. Billy, business being business, turned again to Luella
+            Granville Waterman, but Pugsy, having no immediate duties on hand,
+            concentrated himself on the cat. </p>
+          <p> A waiter made an ingratiating gesture towards the basket, but the young
+            man stopped him. "Not on your life, sonny," he said. "This stays right
+            here." He placed it carefully on the floor beside his chair, and proceeded to order dinner. </p>
+          <p> When the brother becomes the father, a suspicious death shall bring forth
+            bloodshed of blue blood and the return of monsters. </p>
+          <p>The day fire burns blue, the prophet shall cause an age of anarchy.</p>
+        </div>
+
+
+        <div cviNgToCSection="section-five">
+          <h1>Section Five</h1>
+          <p>Billy Windsor had started life twenty-five years before this story opens on his father's ranch in Wyoming. From there he had gone to a local paper of the type whose Society column consists of such items as "Pawnee Jim Williams was to town yesterday with a bunch of other cheap skates. We take this opportunity of once more informing Jim that he is a liar and a skunk," and whose editor works with a revolver on his desk and another in his hip-pocket. Graduating from this, he had proceeded to a reporter's post on a daily paper in a Kentucky town, where there were blood feuds and other Southern devices for preventing life from becoming dull. All this time New York, the magnet, had been tugging at him. All reporters dream of reaching New York. At last, after four years on the Kentucky paper, he had come East, minus the lobe of one ear and plus a long scar that ran diagonally across his left shoulder, and had worked without much success as a free-lance. He was tough and ready for anything that might come his way, but these things are a great deal a matter of luck. The cub-reporter cannot make a name for himself unless he is favoured by fortune. Things had not come Billy Windsor's way. His work had been confined to turning in reports of fires and small street accidents, which the various papers to which he supplied them cut down to a couple of inches.</p>
+          <p>This Pokemon is a ghost-type Pokemon and slightly resembles a toad. It has crimson skin, hidden legs and a serious looking mouth. They're generally fearful by nature and can often be found near graveyards. If you're out looking for them they can often be seen on their own. It tends to attack with Confuse Ray and Shadow Ball. It hasn't evolved yet and there are no known evolutions.</p>
+          <p>This Pokemon is a ghost-type Pokemon and slightly resembles a toad. It has crimson skin, hidden legs and a serious looking mouth. They're generally fearful by nature and can often be found near graveyards. If you're out looking for them they can often be seen on their own. It tends to attack with Confuse Ray and Shadow Ball. It hasn't evolved yet and there are no known evolutions.</p>
+          <p>Billy's first act on arriving in this sanctum was to release the cat, which, having moved restlessly about for some moments, finally came to the conclusion that there was no means of getting out, and settled itself on a corner of the settee. Psmith, sinking gracefully down beside it, stretched out his legs and lit a cigarette. Mike took one of the ordinary chairs; and Billy Windsor, planting himself in the rocker, began to rock rhythmically to and fro, a performance which he kept up untiringly all the time.</p>
+          <p>"Then let us stagger forth with Comrade Windsor. While he is loading up that basket, we will be collecting our hats. . . . I am not half sure, Comrade Jackson," he added, as they walked out, "that Comrade Windsor may not prove to be the genial spirit for whom I have been searching. If you could give me your undivided company, I should ask no more. But with you constantly away, mingling with the gay throng, it is imperative that I have some solid man to accompany me in my ramblings hither and thither. It is possible that Comrade Windsor may possess the qualifications necessary for the post. But here he comes. Let us foregather with him and observe him in private life before arriving at any premature decision."</p>
+          <p>It shall be then, when the sky is thick with water, a secret meeting shall usher forth an end to the gods and the rise of mankind.</p>
+          <p>A waiter made an ingratiating gesture towards the basket, but the young man stopped him. "Not on your life, sonny," he said. "This stays right here." He placed it carefully on the floor beside his chair, and proceeded to order dinner.</p>
+          <p>The day legend becomes history, an embarrassing defeat shall usher forth the return of monsters and an age of growth.</p>
+          <p>When the brother becomes the father, a suspicious death shall bring forth bloodshed of blue blood and the return of monsters.</p>
+          <p>It shall be then, when rocks will rain from the sky, a man clad in green shall bring forth a rise of faith.</p>
+          <p>It shall be on the day that the world becomes shrouded in shadows, the prophet shall bring an eternal night and a change of leadership.</p>
+          <p>The day legend becomes history, an embarrassing defeat shall usher forth the return of monsters and an age of growth.</p>
+          <p>When the day comes that brothers clash, a suspicious malfunction shall usher forth a rise of a new god and an age of inhumanity.</p>
+          <p>A waiter made an ingratiating gesture towards the basket, but the young man stopped him. "Not on your life, sonny," he said. "This stays right here." He placed it carefully on the floor beside his chair, and proceeded to order dinner.</p>
+          <p>There comes a day when mountains move and rivers shiver, a refusal shall bring the end of leadership.</p>
+          <p>As soon as the day is shortest, a sudden death shall cause a country's new rise and an age of bliss.</p>
+          <p>This Pokemon is a ice-type Pokemon and looks a lot like an antelope. It has snowy legs, an icicle covered tail and frosty ears. They're generally playful by nature and can often be found in winter. If you're out looking for them they can often be seen lurking about and on their own. It tends to attack with Haze and Ice Punch. It hasn't evolved yet and there are no known evolutions.</p>
+        </div>
+      </div>
+
+      <cvi-ng-table-of-contents [title]="title" cviNgStorybookCurrentComponent>
+        <cvi-ng-table-of-contents-item label="Section One with a very long label that spans many lines" href="#section-one"></cvi-ng-table-of-contents-item>
+        <cvi-ng-table-of-contents-item label="Section Two" href="#section-two"></cvi-ng-table-of-contents-item>
+        <cvi-ng-table-of-contents-item label="Section Three" href="#section-three"></cvi-ng-table-of-contents-item>
+        <cvi-ng-table-of-contents-item label="Section Four" href="#section-four"></cvi-ng-table-of-contents-item>
+        <cvi-ng-table-of-contents-item label="Section Five" href="#section-five"></cvi-ng-table-of-contents-item>
+      </cvi-ng-table-of-contents>
+    </cvi-ng-table-of-contents-wrapper>
+  `,
+});
+
+export const Default = Template.bind({});
+
+const TemplateWithRandomText: Story<TableOfContentsComponent> = (
+  args: TableOfContentsComponent
+) => ({
+  component: TableOfContentsComponent,
+  props: {
+    ...args,
+  },
+  /* template */
+  template: `
+    <cvi-ng-table-of-contents-wrapper>
+      <div>
+        <div cviNgToCSection="section-one">
+          <h1>Section One</h1>
           <div [cviNgStorybookRandomParagraphs]="10"></div>
         </div>
 
@@ -63,4 +217,8 @@ const Template: Story<TableOfContentsComponent> = (
   `,
 });
 
-export const Default = Template.bind({});
+export const WithRandomText = TemplateWithRandomText.bind({});
+WithRandomText.parameters = {
+  // disabling Chromatic because random text will trigger changes on each run
+  chromatic: { disableSnapshot: true },
+};

--- a/libs/ui/src/lib/tabs/tab-group.component.stories.ts
+++ b/libs/ui/src/lib/tabs/tab-group.component.stories.ts
@@ -6,16 +6,28 @@ export default {
   title: 'Angular/Tab group',
   component: TabGroupComponent,
   parameters: { notes },
-  argTypes: {},
+  argTypes: {
+    content: {
+      name: 'Content',
+      table: {
+        category: 'Playground',
+      },
+      control: { type: 'text' },
+    },
+  },
+  args: {
+    content: 'First tab content with some more text that might overflow',
+  },
 } as Meta;
 
 const Template: Story<TabGroupComponent> = (args: TabGroupComponent) => ({
   props: {
     ...args,
   },
+  /* template */
   template: `
     <cvi-ng-tab-group>
-      <cvi-ng-tab title="Tab 1">First tab content</cvi-ng-tab>
+      <cvi-ng-tab title="Tab 1">{{ content }}</cvi-ng-tab>
       <cvi-ng-tab title="Tab 2">Second tab content</cvi-ng-tab>
     </cvi-ng-tab-group>
   `,

--- a/libs/ui/src/lib/textarea/textarea.component.stories.ts
+++ b/libs/ui/src/lib/textarea/textarea.component.stories.ts
@@ -7,7 +7,11 @@ import { UiModule } from '../ui.module';
 
 export default {
   title: 'Angular/Form/Textarea',
-  parameters: { notes },
+  parameters: {
+    notes,
+    // Disabling Chromatic because cvi-ng-textarea triggers a visual change on every build
+    chromatic: { disableSnapshot: true },
+  },
   decorators: [
     moduleMetadata({
       imports: [UiModule, ReactiveFormsModule],
@@ -23,6 +27,7 @@ export default {
 
 const Template: Story<TextareaComponent> = (args: TextareaComponent) => ({
   props: args,
+  /* template */
   template: `
     <cvi-ng-textarea [disabled]="disabled" [maxLength]="maxLength" [minRows]="minRows" [maxRows]="maxRows" [placeholder]="placeholder" [htmlId]="htmlId" [resizable]="resizable"></cvi-ng-textarea>
   `,

--- a/libs/ui/src/lib/track/track-quick-start.stories.mdx
+++ b/libs/ui/src/lib/track/track-quick-start.stories.mdx
@@ -54,7 +54,7 @@ Note: by default some form controls have a maximum width. You can set `--cvi-tex
 The variables can be set anywhere in a common parent eg. via `[ngStyle]`.
 
 <Canvas>
-  <Story name="Flexible form items" height="200px">
+  <Story name="Flexible form items" height="200px" parameters={{ chromatic: { disableSnapshot: true } }}>
     {{
       template: `
         <cvi-ng-track [gap]="3" [flexColumnsEqual]="true" [flexIsMultiline]="true" verticalAlignment="bottom" [ngStyle]="{'--cvi-textfield--single-line--max-width': '100%', '--cvi-textfield--multiple-lines--max-width': '100%'}">
@@ -86,7 +86,7 @@ Yes, you can. Create a track and set it to `flexDirection="vertical"` with some 
 See the previous question to stretch a form item to all available width.
 
 <Canvas>
-  <Story name="Two row fixed form items" height="200px">
+  <Story name="Two row fixed form items" height="200px" parameters={{ chromatic: { disableSnapshot: true } }}>
     {{
       template: `
         <cvi-ng-track [gap]="3" flexDirection="vertical">
@@ -118,7 +118,7 @@ See the previous question to stretch a form item to all available width.
 Yes, just use `layout="grid"`. Items will wrap automatically into multiple rows if needed.
 
 <Canvas>
-  <Story name="Form items as a grid" height="200px">
+  <Story name="Form items as a grid" height="200px" parameters={{ chromatic: { disableSnapshot: true } }}>
     {{
       template: `
         <cvi-ng-track [gap]="3" layout="grid" verticalAlignment="bottom">

--- a/libs/ui/src/lib/track/track.component.stories.ts
+++ b/libs/ui/src/lib/track/track.component.stories.ts
@@ -15,7 +15,7 @@ const categoryGrid = {
 };
 
 export default {
-  title: 'Angular/Track',
+  title: 'Angular/Track/Stories',
   component: TrackComponent,
   parameters: {
     notes,

--- a/libs/ui/src/lib/track/track.component.stories.ts
+++ b/libs/ui/src/lib/track/track.component.stories.ts
@@ -280,6 +280,10 @@ WithEqualSizeFormItemsGridCol.args = {
 
 export const WithFormItemsComplex = TemplateWithFormItemsComplex.bind({});
 WithFormItemsComplex.storyName = 'With form items (complex layout)';
+WithFormItemsComplex.parameters = {
+  // Disabling Chromatic because cvi-ng-textarea triggers a visual change on every build
+  chromatic: { disableSnapshot: true },
+};
 WithFormItemsComplex.argTypes = {
   repeatableItemsFlex: {
     name: 'Number of repeatable items (first track)',

--- a/package-lock.json
+++ b/package-lock.json
@@ -67,6 +67,7 @@
         "@typescript-eslint/eslint-plugin": "5.45.0",
         "@typescript-eslint/parser": "5.45.0",
         "@whitespace/storybook-addon-html": "^5.0.0",
+        "chromatic": "^6.17.2",
         "cpy-cli": "^4.2.0",
         "cypress": "10.8.0",
         "cypress-storybook": "^0.5.1",
@@ -855,6 +856,15 @@
         "@angular/core": "14.2.12",
         "@angular/platform-browser": "14.2.12",
         "rxjs": "^6.5.3 || ^7.4.0"
+      }
+    },
+    "node_modules/@arcanis/slice-ansi": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@arcanis/slice-ansi/-/slice-ansi-1.1.1.tgz",
+      "integrity": "sha512-xguP2WR2Dv0gQ7Ykbdb7BNCnPnIPB94uTi0Z2NvkRBEnhbwjOQ7QyQKJXrVQg4qDpiD9hA5l5cCwy/z2OXgc3w==",
+      "dev": true,
+      "dependencies": {
+        "grapheme-splitter": "^1.0.4"
       }
     },
     "node_modules/@assemblyscript/loader": {
@@ -8313,6 +8323,18 @@
       "version": "0.24.51",
       "license": "MIT"
     },
+    "node_modules/@sindresorhus/is": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
+      "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
     "node_modules/@sinonjs/commons": {
       "version": "1.8.6",
       "license": "BSD-3-Clause",
@@ -8325,6 +8347,59 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "node_modules/@snyk/dep-graph": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@snyk/dep-graph/-/dep-graph-2.5.0.tgz",
+      "integrity": "sha512-wFKHAhsD1VBfESiuN2nHHeulEYAAod1Z4E/2t+ztsiJ5DCeD0pSXtJizdp2PhMZ0cFFce8ln3NO8xBhl+C4H+Q==",
+      "dev": true,
+      "dependencies": {
+        "event-loop-spinner": "^2.1.0",
+        "lodash.clone": "^4.5.0",
+        "lodash.constant": "^3.0.0",
+        "lodash.filter": "^4.6.0",
+        "lodash.foreach": "^4.5.0",
+        "lodash.isempty": "^4.4.0",
+        "lodash.isequal": "^4.5.0",
+        "lodash.isfunction": "^3.0.9",
+        "lodash.isundefined": "^3.0.1",
+        "lodash.map": "^4.6.0",
+        "lodash.reduce": "^4.6.0",
+        "lodash.size": "^4.2.0",
+        "lodash.transform": "^4.6.0",
+        "lodash.union": "^4.6.0",
+        "lodash.values": "^4.3.0",
+        "object-hash": "^3.0.0",
+        "packageurl-js": "^1.0.0",
+        "semver": "^7.0.0",
+        "tslib": "^2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@snyk/graphlib": {
+      "version": "2.1.9-patch.3",
+      "resolved": "https://registry.npmjs.org/@snyk/graphlib/-/graphlib-2.1.9-patch.3.tgz",
+      "integrity": "sha512-bBY9b9ulfLj0v2Eer0yFYa3syVeIxVKl2EpxSrsVeT4mjA0CltZyHsF0JjoaGXP27nItTdJS5uVsj1NA+3aE+Q==",
+      "dev": true,
+      "dependencies": {
+        "lodash.clone": "^4.5.0",
+        "lodash.constant": "^3.0.0",
+        "lodash.filter": "^4.6.0",
+        "lodash.foreach": "^4.5.0",
+        "lodash.has": "^4.5.2",
+        "lodash.isempty": "^4.4.0",
+        "lodash.isfunction": "^3.0.9",
+        "lodash.isundefined": "^3.0.1",
+        "lodash.keys": "^4.2.0",
+        "lodash.map": "^4.6.0",
+        "lodash.reduce": "^4.6.0",
+        "lodash.size": "^4.2.0",
+        "lodash.transform": "^4.6.0",
+        "lodash.union": "^4.6.0",
+        "lodash.values": "^4.3.0"
       }
     },
     "node_modules/@storybook/addon-a11y": {
@@ -9930,11 +10005,14 @@
       }
     },
     "node_modules/@storybook/addon-controls/node_modules/watchpack/chokidar2": {
-      "version": "0.0.1",
+      "version": "2.0.0",
       "dev": true,
       "optional": true,
       "dependencies": {
         "chokidar": "^2.1.8"
+      },
+      "engines": {
+        "node": "<8.10.0"
       }
     },
     "node_modules/@storybook/addon-controls/node_modules/webpack": {
@@ -26621,6 +26699,18 @@
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
+    "node_modules/@szmarczak/http-timer": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
+      "integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
+      "dev": true,
+      "dependencies": {
+        "defer-to-connect": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@tootallnate/once": {
       "version": "2.0.0",
       "dev": true,
@@ -26731,6 +26821,18 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cacheable-request": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
+      "integrity": "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==",
+      "dev": true,
+      "dependencies": {
+        "@types/http-cache-semantics": "*",
+        "@types/keyv": "^3.1.4",
+        "@types/node": "*",
+        "@types/responselike": "^1.0.0"
+      }
+    },
     "node_modules/@types/connect": {
       "version": "3.4.35",
       "license": "MIT",
@@ -26745,6 +26847,12 @@
         "@types/express-serve-static-core": "*",
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/emscripten": {
+      "version": "1.39.6",
+      "resolved": "https://registry.npmjs.org/@types/emscripten/-/emscripten-1.39.6.tgz",
+      "integrity": "sha512-H90aoynNhhkQP6DRweEjJp5vfUVdIj7tdPLsu7pq89vODD/lcugKfZOsfgwpvM6XUewEp2N5dCg1Uf3Qe55Dcg==",
+      "dev": true
     },
     "node_modules/@types/eslint": {
       "version": "8.4.10",
@@ -26813,6 +26921,12 @@
       "version": "6.1.0",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/@types/http-cache-semantics": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz",
+      "integrity": "sha512-SZs7ekbP8CN0txVG2xVRH6EgKmEm31BOxA07vkFaETzZz1xh+cbt8BcI0slpymvwhx5dlFnQG2rTlPVQn+iRPQ==",
+      "dev": true
     },
     "node_modules/@types/http-proxy": {
       "version": "1.17.9",
@@ -26998,6 +27112,15 @@
       "version": "0.0.29",
       "license": "MIT"
     },
+    "node_modules/@types/keyv": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
+      "integrity": "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/lodash": {
       "version": "4.14.191",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.191.tgz",
@@ -27108,6 +27231,15 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/responselike": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.0.tgz",
+      "integrity": "sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/retry": {
       "version": "0.12.0",
       "license": "MIT"
@@ -27176,6 +27308,12 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/tapable/-/tapable-1.0.8.tgz",
       "integrity": "sha512-ipixuVrh2OdNmauvtT51o3d8z12p6LtFW9in7U79der/kwejjdNchQC5UMn5u/KxNoM7VHHOs/l8KS8uHxhODQ==",
+      "dev": true
+    },
+    "node_modules/@types/treeify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/treeify/-/treeify-1.0.0.tgz",
+      "integrity": "sha512-ONpcZAEYlbPx4EtJwfTyCDQJGUpKf4sEcuySdCVjK5Fj/3vHp5HII1fqa1/+qrsLnpYELCQTfVW/awsGJePoIg==",
       "dev": true
     },
     "node_modules/@types/uglify-js": {
@@ -27914,6 +28052,224 @@
       "version": "4.2.2",
       "license": "Apache-2.0"
     },
+    "node_modules/@yarnpkg/core": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/core/-/core-2.4.0.tgz",
+      "integrity": "sha512-FYjcPNTfDfMKLFafQPt49EY28jnYC82Z2S7oMwLPUh144BL8v8YXzb4aCnFyi5nFC5h2kcrJfZh7+Pm/qvCqGw==",
+      "dev": true,
+      "dependencies": {
+        "@arcanis/slice-ansi": "^1.0.2",
+        "@types/semver": "^7.1.0",
+        "@types/treeify": "^1.0.0",
+        "@yarnpkg/fslib": "^2.4.0",
+        "@yarnpkg/json-proxy": "^2.1.0",
+        "@yarnpkg/libzip": "^2.2.1",
+        "@yarnpkg/parsers": "^2.3.0",
+        "@yarnpkg/pnp": "^2.3.2",
+        "@yarnpkg/shell": "^2.4.1",
+        "binjumper": "^0.1.4",
+        "camelcase": "^5.3.1",
+        "chalk": "^3.0.0",
+        "ci-info": "^2.0.0",
+        "clipanion": "^2.6.2",
+        "cross-spawn": "7.0.3",
+        "diff": "^4.0.1",
+        "globby": "^11.0.1",
+        "got": "^11.7.0",
+        "json-file-plus": "^3.3.1",
+        "lodash": "^4.17.15",
+        "micromatch": "^4.0.2",
+        "mkdirp": "^0.5.1",
+        "p-limit": "^2.2.0",
+        "pluralize": "^7.0.0",
+        "pretty-bytes": "^5.1.0",
+        "semver": "^7.1.2",
+        "stream-to-promise": "^2.2.0",
+        "tar-stream": "^2.0.1",
+        "treeify": "^1.1.0",
+        "tslib": "^1.13.0",
+        "tunnel": "^0.0.6"
+      },
+      "engines": {
+        "node": ">=10.19.0"
+      }
+    },
+    "node_modules/@yarnpkg/core/node_modules/@yarnpkg/parsers": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/parsers/-/parsers-2.5.1.tgz",
+      "integrity": "sha512-KtYN6Ez3x753vPF9rETxNTPnPjeaHY11Exlpqb4eTII7WRlnGiZ5rvvQBau4R20Ik5KBv+vS3EJEcHyCunwzzw==",
+      "dev": true,
+      "dependencies": {
+        "js-yaml": "^3.10.0",
+        "tslib": "^1.13.0"
+      },
+      "engines": {
+        "node": ">=12 <14 || 14.2 - 14.9 || >14.10.0"
+      }
+    },
+    "node_modules/@yarnpkg/core/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@yarnpkg/core/node_modules/chalk": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@yarnpkg/core/node_modules/ci-info": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+      "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+      "dev": true
+    },
+    "node_modules/@yarnpkg/core/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@yarnpkg/core/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/@yarnpkg/core/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@yarnpkg/core/node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "dev": true,
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/@yarnpkg/core/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@yarnpkg/core/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@yarnpkg/core/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
+    },
+    "node_modules/@yarnpkg/fslib": {
+      "version": "2.10.2",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/fslib/-/fslib-2.10.2.tgz",
+      "integrity": "sha512-6WfQrPEV8QVpDPw5kd5s5jsb3QLqwVFSGZy3rEjl3p2FZ3OtIfYcLbFirOxXj2jXiKQDe7XbYsw1WjSf8K94gw==",
+      "dev": true,
+      "dependencies": {
+        "@yarnpkg/libzip": "^2.3.0",
+        "tslib": "^1.13.0"
+      },
+      "engines": {
+        "node": ">=12 <14 || 14.2 - 14.9 || >14.10.0"
+      }
+    },
+    "node_modules/@yarnpkg/fslib/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
+    },
+    "node_modules/@yarnpkg/json-proxy": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/json-proxy/-/json-proxy-2.1.1.tgz",
+      "integrity": "sha512-meUiCAgCYpXTH1qJfqfz+dX013ohW9p2dKfwIzUYAFutH+lsz1eHPBIk72cuCV84adh9gX6j66ekBKH/bIhCQw==",
+      "dev": true,
+      "dependencies": {
+        "@yarnpkg/fslib": "^2.5.0",
+        "tslib": "^1.13.0"
+      },
+      "engines": {
+        "node": ">=12 <14 || 14.2 - 14.9 || >14.10.0"
+      }
+    },
+    "node_modules/@yarnpkg/json-proxy/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
+    },
+    "node_modules/@yarnpkg/libzip": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/libzip/-/libzip-2.3.0.tgz",
+      "integrity": "sha512-6xm38yGVIa6mKm/DUCF2zFFJhERh/QWp1ufm4cNUvxsONBmfPg8uZ9pZBdOmF6qFGr/HlT6ABBkCSx/dlEtvWg==",
+      "dev": true,
+      "dependencies": {
+        "@types/emscripten": "^1.39.6",
+        "tslib": "^1.13.0"
+      },
+      "engines": {
+        "node": ">=12 <14 || 14.2 - 14.9 || >14.10.0"
+      }
+    },
+    "node_modules/@yarnpkg/libzip/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
+    },
     "node_modules/@yarnpkg/lockfile": {
       "version": "1.1.0",
       "license": "BSD-2-Clause"
@@ -27928,6 +28284,73 @@
       "engines": {
         "node": ">=14.15.0"
       }
+    },
+    "node_modules/@yarnpkg/pnp": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/pnp/-/pnp-2.3.2.tgz",
+      "integrity": "sha512-JdwHu1WBCISqJEhIwx6Hbpe8MYsYbkGMxoxolkDiAeJ9IGEe08mQcbX1YmUDV1ozSWlm9JZE90nMylcDsXRFpA==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "^13.7.0",
+        "@yarnpkg/fslib": "^2.4.0",
+        "tslib": "^1.13.0"
+      },
+      "engines": {
+        "node": ">=10.19.0"
+      }
+    },
+    "node_modules/@yarnpkg/pnp/node_modules/@types/node": {
+      "version": "13.13.52",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.52.tgz",
+      "integrity": "sha512-s3nugnZumCC//n4moGGe6tkNMyYEdaDBitVjwPxXmR5lnMG5dHePinH2EdxkG3Rh1ghFHHixAG4NJhpJW1rthQ==",
+      "dev": true
+    },
+    "node_modules/@yarnpkg/pnp/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
+    },
+    "node_modules/@yarnpkg/shell": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/shell/-/shell-2.4.1.tgz",
+      "integrity": "sha512-oNNJkH8ZI5uwu0dMkJf737yMSY1WXn9gp55DqSA5wAOhKvV5DJTXFETxkVgBQhO6Bow9tMGSpvowTMD/oAW/9g==",
+      "dev": true,
+      "dependencies": {
+        "@yarnpkg/fslib": "^2.4.0",
+        "@yarnpkg/parsers": "^2.3.0",
+        "clipanion": "^2.6.2",
+        "cross-spawn": "7.0.3",
+        "fast-glob": "^3.2.2",
+        "micromatch": "^4.0.2",
+        "stream-buffers": "^3.0.2",
+        "tslib": "^1.13.0"
+      },
+      "bin": {
+        "shell": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=10.19.0"
+      }
+    },
+    "node_modules/@yarnpkg/shell/node_modules/@yarnpkg/parsers": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/parsers/-/parsers-2.5.1.tgz",
+      "integrity": "sha512-KtYN6Ez3x753vPF9rETxNTPnPjeaHY11Exlpqb4eTII7WRlnGiZ5rvvQBau4R20Ik5KBv+vS3EJEcHyCunwzzw==",
+      "dev": true,
+      "dependencies": {
+        "js-yaml": "^3.10.0",
+        "tslib": "^1.13.0"
+      },
+      "engines": {
+        "node": ">=12 <14 || 14.2 - 14.9 || >14.10.0"
+      }
+    },
+    "node_modules/@yarnpkg/shell/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
     },
     "node_modules/@zkochan/js-yaml": {
       "version": "0.0.6",
@@ -28297,6 +28720,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true
+    },
     "node_modules/anymatch": {
       "version": "3.1.3",
       "license": "ISC",
@@ -28556,6 +28985,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true
     },
     "node_modules/asn1": {
       "version": "0.2.6",
@@ -29501,6 +29936,15 @@
         "file-uri-to-path": "1.0.0"
       }
     },
+    "node_modules/binjumper": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/binjumper/-/binjumper-0.1.4.tgz",
+      "integrity": "sha512-Gdxhj+U295tIM6cO4bJO1jsvSjBVHNpj2o/OwW7pqDEtaqF6KdOxjtbo93jMMKAkP7+u09+bV8DhSqjIv4qR3w==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.12.0"
+      }
+    },
     "node_modules/bl": {
       "version": "4.1.0",
       "license": "MIT",
@@ -30054,6 +30498,48 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/cacheable-lookup": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
+      "integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.6.0"
+      }
+    },
+    "node_modules/cacheable-request": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.2.tgz",
+      "integrity": "sha512-pouW8/FmiPQbuGpkXQ9BAPv/Mo5xDGANgSNXzTzJ8DrKGuXOssM4wIQRjfanNRh3Yu5cfYPvcorqbhg2KIJtew==",
+      "dev": true,
+      "dependencies": {
+        "clone-response": "^1.0.2",
+        "get-stream": "^5.1.0",
+        "http-cache-semantics": "^4.0.0",
+        "keyv": "^4.0.0",
+        "lowercase-keys": "^2.0.0",
+        "normalize-url": "^6.0.1",
+        "responselike": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cacheable-request/node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/cachedir": {
       "version": "2.3.0",
       "devOptional": true,
@@ -30372,6 +30858,22 @@
         "node": ">=10"
       }
     },
+    "node_modules/chromatic": {
+      "version": "6.17.2",
+      "resolved": "https://registry.npmjs.org/chromatic/-/chromatic-6.17.2.tgz",
+      "integrity": "sha512-rtrkywh1CuDDuuiRWXpdiX38aEGN3sGCATsgdh3X/EUBjQjgQtEbSzcMusC3cqz3K9dFKcWwKpFm3jaw9gNymA==",
+      "dev": true,
+      "dependencies": {
+        "@discoveryjs/json-ext": "^0.5.7",
+        "@types/webpack-env": "^1.17.0",
+        "snyk-nodejs-lockfile-parser": "^1.47.4"
+      },
+      "bin": {
+        "chroma": "bin/main.cjs",
+        "chromatic": "bin/main.cjs",
+        "chromatic-cli": "bin/main.cjs"
+      }
+    },
     "node_modules/chrome-trace-event": {
       "version": "1.0.3",
       "license": "MIT",
@@ -30584,6 +31086,12 @@
         "node": ">= 10"
       }
     },
+    "node_modules/clipanion": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/clipanion/-/clipanion-2.6.2.tgz",
+      "integrity": "sha512-0tOHJNMF9+4R3qcbBL+4IxLErpaYSYvzs10aXuECDbZdJOuJHdagJMAqvLdeaUQTI/o2uSCDRpet6ywDiKOAYw==",
+      "dev": true
+    },
     "node_modules/cliui": {
       "version": "7.0.4",
       "license": "ISC",
@@ -30610,6 +31118,18 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/clone-response": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
+      "integrity": "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==",
+      "dev": true,
+      "dependencies": {
+        "mimic-response": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/co": {
@@ -32889,6 +33409,33 @@
         "node": ">=0.10"
       }
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "dev": true,
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/decompress-response/node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/dedent": {
       "version": "0.7.0",
       "license": "MIT"
@@ -33211,6 +33758,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/defer-to-connect": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
+      "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/define-lazy-prop": {
@@ -34596,6 +35152,15 @@
       "dependencies": {
         "d": "1",
         "es5-ext": "~0.10.14"
+      }
+    },
+    "node_modules/event-loop-spinner": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/event-loop-spinner/-/event-loop-spinner-2.2.0.tgz",
+      "integrity": "sha512-KB44sV4Mv7uLIkJHJ5qhiZe5um6th2g57nHQL/uqnPHKP2IswoTRWUteEXTJQL4gW++1zqWUni+H2hGkP51c9w==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
       }
     },
     "node_modules/event-stream": {
@@ -36689,9 +37254,40 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/got": {
+      "version": "11.8.6",
+      "resolved": "https://registry.npmjs.org/got/-/got-11.8.6.tgz",
+      "integrity": "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==",
+      "dev": true,
+      "dependencies": {
+        "@sindresorhus/is": "^4.0.0",
+        "@szmarczak/http-timer": "^4.0.5",
+        "@types/cacheable-request": "^6.0.1",
+        "@types/responselike": "^1.0.0",
+        "cacheable-lookup": "^5.0.3",
+        "cacheable-request": "^7.0.2",
+        "decompress-response": "^6.0.0",
+        "http2-wrapper": "^1.0.0-beta.5.2",
+        "lowercase-keys": "^2.0.0",
+        "p-cancelable": "^2.0.0",
+        "responselike": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/got?sponsor=1"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.10",
       "license": "ISC"
+    },
+    "node_modules/grapheme-splitter": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
+      "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
+      "dev": true
     },
     "node_modules/handle-thing": {
       "version": "2.0.1",
@@ -37481,6 +38077,31 @@
         "node": ">=0.10"
       }
     },
+    "node_modules/http2-wrapper": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
+      "integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
+      "dev": true,
+      "dependencies": {
+        "quick-lru": "^5.1.1",
+        "resolve-alpn": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=10.19.0"
+      }
+    },
+    "node_modules/http2-wrapper/node_modules/quick-lru": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/https-browserify": {
       "version": "1.0.0",
       "dev": true,
@@ -37928,6 +38549,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/is": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/is/-/is-3.3.0.tgz",
+      "integrity": "sha512-nW24QBoPcFGGHJGUwnfpI7Yc5CdqWNdsyHQszVE/z2pKHXzh7FZ5GWhJqSyaQ9wMkQnsTx+kAI8bHlCX4tKdbg==",
+      "dev": true,
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/is-absolute-url": {
@@ -42891,6 +43521,28 @@
         "node": ">=4"
       }
     },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true
+    },
+    "node_modules/json-file-plus": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/json-file-plus/-/json-file-plus-3.3.1.tgz",
+      "integrity": "sha512-wo0q1UuiV5NsDPQDup1Km8IwEeqe+olr8tkWxeJq9Bjtcp7DZ0l+yrg28fSC3DEtrE311mhTZ54QGS6oiqnZEA==",
+      "dev": true,
+      "dependencies": {
+        "is": "^3.2.1",
+        "node.extend": "^2.0.0",
+        "object.assign": "^4.1.0",
+        "promiseback": "^2.0.2",
+        "safer-buffer": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/json-parse-better-errors": {
       "version": "1.0.2",
       "dev": true,
@@ -42997,6 +43649,15 @@
       "license": "MIT",
       "dependencies": {
         "source-map-support": "^0.5.5"
+      }
+    },
+    "node_modules/keyv": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.2.tgz",
+      "integrity": "sha512-5MHbFaKn8cNSmVW7BYnijeAVlE4cYA/SVkifVgrh7yotnfhKmjuXpDKjrABLnT0SfHWV21P8ow07OGfRrNDg8g==",
+      "dev": true,
+      "dependencies": {
+        "json-buffer": "3.0.1"
       }
     },
     "node_modules/kind-of": {
@@ -43263,9 +43924,69 @@
       "version": "4.3.0",
       "license": "MIT"
     },
+    "node_modules/lodash.clone": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clone/-/lodash.clone-4.5.0.tgz",
+      "integrity": "sha512-GhrVeweiTD6uTmmn5hV/lzgCQhccwReIVRLHp7LT4SopOjqEZ5BbX8b5WWEtAKasjmy8hR7ZPwsYlxRCku5odg==",
+      "dev": true
+    },
+    "node_modules/lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
+      "dev": true
+    },
+    "node_modules/lodash.constant": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.constant/-/lodash.constant-3.0.0.tgz",
+      "integrity": "sha512-X5XMrB+SdI1mFa81162NSTo/YNd23SLdLOLzcXTwS4inDZ5YCL8X67UFzZJAH4CqIa6R8cr56CShfA5K5MFiYQ==",
+      "dev": true
+    },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
       "license": "MIT"
+    },
+    "node_modules/lodash.filter": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.filter/-/lodash.filter-4.6.0.tgz",
+      "integrity": "sha512-pXYUy7PR8BCLwX5mgJ/aNtyOvuJTdZAo9EQFUvMIYugqmJxnrYaANvTbgndOzHSCSR0wnlBBfRXJL5SbWxo3FQ==",
+      "dev": true
+    },
+    "node_modules/lodash.flatmap": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.flatmap/-/lodash.flatmap-4.5.0.tgz",
+      "integrity": "sha512-/OcpcAGWlrZyoHGeHh3cAoa6nGdX6QYtmzNP84Jqol6UEQQ2gIaU3H+0eICcjcKGl0/XF8LWOujNn9lffsnaOg==",
+      "dev": true
+    },
+    "node_modules/lodash.foreach": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-4.5.0.tgz",
+      "integrity": "sha512-aEXTF4d+m05rVOAUG3z4vZZ4xVexLKZGF0lIxuHZ1Hplpk/3B6Z1+/ICICYRLm7c41Z2xiejbkCkJoTlypoXhQ==",
+      "dev": true
+    },
+    "node_modules/lodash.has": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/lodash.has/-/lodash.has-4.5.2.tgz",
+      "integrity": "sha512-rnYUdIo6xRCJnQmbVFEwcxF144erlD+M3YcJUVesflU9paQaE8p+fJDcIQrlMYbxoANFL+AB9hZrzSBBk5PL+g==",
+      "dev": true
+    },
+    "node_modules/lodash.isempty": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.isempty/-/lodash.isempty-4.4.0.tgz",
+      "integrity": "sha512-oKMuF3xEeqDltrGMfDxAPGIVMSSRv8tbRSODbrs4KGsRRLEhrW8N8Rd4DRgB2+621hY8A8XwwrTVhXWpxFvMzg==",
+      "dev": true
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "dev": true
+    },
+    "node_modules/lodash.isfunction": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz",
+      "integrity": "sha512-AirXNj15uRIMMPihnkInB4i3NHeb4iBtNg9WRWuK2o31S+ePwwNmDPaTL3o7dTJ+VXNZim7rFs4rxN4YU1oUJw==",
+      "dev": true
     },
     "node_modules/lodash.ismatch": {
       "version": "4.4.0",
@@ -43277,9 +43998,27 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lodash.isundefined": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isundefined/-/lodash.isundefined-3.0.1.tgz",
+      "integrity": "sha512-MXB1is3s899/cD8jheYYE2V9qTHwKvt+npCwpD+1Sxm3Q3cECXCiYHjeHWXNwr6Q0SOBPrYUDxendrO6goVTEA==",
+      "dev": true
+    },
     "node_modules/lodash.kebabcase": {
       "version": "4.1.1",
       "license": "MIT"
+    },
+    "node_modules/lodash.keys": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-4.2.0.tgz",
+      "integrity": "sha512-J79MkJcp7Df5mizHiVNpjoHXLi4HLjh9VLS/M7lQSGoQ+0oQ+lWEigREkqKyizPB1IawvQLLKY8mzEcm1tkyxQ==",
+      "dev": true
+    },
+    "node_modules/lodash.map": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.map/-/lodash.map-4.6.0.tgz",
+      "integrity": "sha512-worNHGKLDetmcEYDvh2stPCrrQRkP20E4l0iIS7F8EvzMqBBi7ltvFN5m1HvTf1P7Jk1txKhvFcmYsCr8O2F1Q==",
+      "dev": true
     },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
@@ -43300,6 +44039,18 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/lodash.reduce": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.reduce/-/lodash.reduce-4.6.0.tgz",
+      "integrity": "sha512-6raRe2vxCYBhpBu+B+TtNGUzah+hQjVdu3E17wfusjyrXBka2nBS8OH/gjVZ5PvHOhWmIZTYri09Z6n/QfnNMw==",
+      "dev": true
+    },
+    "node_modules/lodash.size": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.size/-/lodash.size-4.2.0.tgz",
+      "integrity": "sha512-wbu3SF1XC5ijqm0piNxw59yCbuUf2kaShumYBLWUrcCvwh6C8odz6SY/wGVzCWTQTFL/1Ygbvqg2eLtspUVVAQ==",
+      "dev": true
+    },
     "node_modules/lodash.snakecase": {
       "version": "4.1.1",
       "license": "MIT"
@@ -43309,10 +44060,28 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lodash.topairs": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.topairs/-/lodash.topairs-4.3.0.tgz",
+      "integrity": "sha512-qrRMbykBSEGdOgQLJJqVSdPWMD7Q+GJJ5jMRfQYb+LTLsw3tYVIabnCzRqTJb2WTo17PG5gNzXuFaZgYH/9SAQ==",
+      "dev": true
+    },
+    "node_modules/lodash.transform": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.transform/-/lodash.transform-4.6.0.tgz",
+      "integrity": "sha512-LO37ZnhmBVx0GvOU/caQuipEh4GN82TcWv3yHlebGDgOxbxiwwzW5Pcx2AcvpIv2WmvmSMoC492yQFNhy/l/UQ==",
+      "dev": true
+    },
     "node_modules/lodash.truncate": {
       "version": "4.4.2",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/lodash.union": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
+      "integrity": "sha512-c4pB2CdGrGdjMKYLA+XiRDO7Y0PRQbm/Gzg8qMj+QH+pFVAoTp5sBpO0odL3FjoPCGjK96p6qsP+yQoiLoOBcw==",
+      "dev": true
     },
     "node_modules/lodash.uniq": {
       "version": "4.5.0",
@@ -43322,6 +44091,12 @@
       "version": "4.3.1",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/lodash.values": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.values/-/lodash.values-4.3.0.tgz",
+      "integrity": "sha512-r0RwvdCv8id9TUblb/O7rYPwVy6lerCbcawrfdo9iC/1t1wsNMJknO79WNBgwkH0hIeJ08jmvvESbFpNb4jH0Q==",
+      "dev": true
     },
     "node_modules/log-symbols": {
       "version": "4.1.0",
@@ -43518,6 +44293,15 @@
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/lowercase-keys": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+      "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/lowlight": {
@@ -44031,6 +44815,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/mimic-response": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/min-document": {
@@ -44996,6 +45789,19 @@
       "version": "2.0.6",
       "license": "MIT"
     },
+    "node_modules/node.extend": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/node.extend/-/node.extend-2.0.2.tgz",
+      "integrity": "sha512-pDT4Dchl94/+kkgdwyS2PauDFjZG0Hk0IcHIB+LkW27HLDtdoeMxHTxZh39DYbPP8UflWXWj9JcdDozF+YDOpQ==",
+      "dev": true,
+      "dependencies": {
+        "has": "^1.0.3",
+        "is": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/nopt": {
       "version": "6.0.0",
       "dev": true,
@@ -45497,6 +46303,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/object-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/object-inspect": {
       "version": "1.12.2",
       "license": "MIT",
@@ -45855,6 +46670,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/p-cancelable": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
+      "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/p-defer": {
       "version": "1.0.0",
       "dev": true,
@@ -46040,6 +46864,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/packageurl-js": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/packageurl-js/-/packageurl-js-1.0.1.tgz",
+      "integrity": "sha512-EtXC0kgLjy/C7S4SN3Kk1SDRWLzIn/LUK0gXlz3gsxDdpI0k7q8C3SASpV0pc+v0yADBTt5rWewq/flGdGxtoQ==",
+      "dev": true
     },
     "node_modules/pacote": {
       "version": "13.6.2",
@@ -46472,6 +47302,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/pluralize": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
+      "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/png-js": {
@@ -47806,6 +48645,30 @@
       "version": "2.0.1",
       "license": "MIT"
     },
+    "node_modules/promise": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+      "dev": true,
+      "dependencies": {
+        "asap": "~2.0.3"
+      }
+    },
+    "node_modules/promise-deferred": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/promise-deferred/-/promise-deferred-2.0.3.tgz",
+      "integrity": "sha512-n10XaoznCzLfyPFOlEE8iurezHpxrYzyjgq/1eW9Wk1gJwur/N7BdBmjJYJpqMeMcXK4wEbzo2EvZQcqjYcKUQ==",
+      "dev": true,
+      "dependencies": {
+        "promise": "^7.3.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/promise-inflight": {
       "version": "1.0.1",
       "dev": true,
@@ -47850,6 +48713,22 @@
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.4",
         "es-abstract": "^1.20.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/promiseback": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/promiseback/-/promiseback-2.0.3.tgz",
+      "integrity": "sha512-VZXdCwS0ppVNTIRfNsCvVwJAaP2b+pxQF7lM8DMWfmpNWyTxB6O5YNbzs+8z0ki/KIBHKHk308NTIl4kJUem3w==",
+      "dev": true,
+      "dependencies": {
+        "is-callable": "^1.1.5",
+        "promise-deferred": "^2.0.3"
       },
       "engines": {
         "node": ">= 0.4"
@@ -48975,6 +49854,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/resolve-alpn": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
+      "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
+      "dev": true
+    },
     "node_modules/resolve-cwd": {
       "version": "3.0.0",
       "dev": true,
@@ -49066,6 +49951,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/responselike": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
+      "integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
+      "dev": true,
+      "dependencies": {
+        "lowercase-keys": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/restore-cursor": {
@@ -50296,6 +51193,80 @@
         "urix": "^0.1.0"
       }
     },
+    "node_modules/snyk-config": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/snyk-config/-/snyk-config-5.1.0.tgz",
+      "integrity": "sha512-wqVMxUGqjjHX+MJrz0WHa/pJTDWU17aRv6cnI/6i7cq93J3TkkJZ8sjgvwCgP8cWX5wTHIlRuMV+IAd59K4X/g==",
+      "dev": true,
+      "dependencies": {
+        "async": "^3.2.0",
+        "debug": "^4.1.1",
+        "lodash.merge": "^4.6.2",
+        "minimist": "^1.2.5"
+      }
+    },
+    "node_modules/snyk-nodejs-lockfile-parser": {
+      "version": "1.48.0",
+      "resolved": "https://registry.npmjs.org/snyk-nodejs-lockfile-parser/-/snyk-nodejs-lockfile-parser-1.48.0.tgz",
+      "integrity": "sha512-kq4gVwL5V0SUatDxyyzbptKkaX4Ew9N3ZDNR5r7sqBRparY+U+xGuYBhTaJdweBUD+jkvs7rKO1JV1h0Z8c2ew==",
+      "dev": true,
+      "dependencies": {
+        "@snyk/dep-graph": "^2.3.0",
+        "@snyk/graphlib": "2.1.9-patch.3",
+        "@yarnpkg/core": "^2.4.0",
+        "@yarnpkg/lockfile": "^1.1.0",
+        "event-loop-spinner": "^2.0.0",
+        "js-yaml": "^4.1.0",
+        "lodash.clonedeep": "^4.5.0",
+        "lodash.flatmap": "^4.5.0",
+        "lodash.isempty": "^4.4.0",
+        "lodash.topairs": "^4.3.0",
+        "micromatch": "^4.0.5",
+        "semver": "^7.3.5",
+        "snyk-config": "^5.0.0",
+        "tslib": "^1.9.3",
+        "uuid": "^8.3.0"
+      },
+      "bin": {
+        "parse-nodejs-lockfile": "bin/index.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/snyk-nodejs-lockfile-parser/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
+    },
+    "node_modules/snyk-nodejs-lockfile-parser/node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/snyk-nodejs-lockfile-parser/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
+    },
+    "node_modules/snyk-nodejs-lockfile-parser/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/sockjs": {
       "version": "0.3.24",
       "license": "MIT",
@@ -51049,6 +52020,15 @@
         "safe-buffer": "~5.1.0"
       }
     },
+    "node_modules/stream-buffers": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-3.0.2.tgz",
+      "integrity": "sha512-DQi1h8VEBA/lURbSwFtEHnSTb9s2/pwLEaFuNhXwy1Dx3Sa0lOuYT2yNUr4/j2fs8oCAMANtrZ5OrPZtyVs3MQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
     "node_modules/stream-combiner": {
       "version": "0.2.2",
       "dev": true,
@@ -51110,6 +52090,44 @@
       "version": "1.0.1",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/stream-to-array": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/stream-to-array/-/stream-to-array-2.3.0.tgz",
+      "integrity": "sha512-UsZtOYEn4tWU2RGLOXr/o/xjRBftZRlG3dEWoaHr8j4GuypJ3isitGbVyjQKAuMu+xbiop8q224TjiZWc4XTZA==",
+      "dev": true,
+      "dependencies": {
+        "any-promise": "^1.1.0"
+      }
+    },
+    "node_modules/stream-to-promise": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/stream-to-promise/-/stream-to-promise-2.2.0.tgz",
+      "integrity": "sha512-HAGUASw8NT0k8JvIVutB2Y/9iBk7gpgEyAudXwNJmZERdMITGdajOa4VJfD/kNiA3TppQpTP4J+CtcHwdzKBAw==",
+      "dev": true,
+      "dependencies": {
+        "any-promise": "~1.3.0",
+        "end-of-stream": "~1.1.0",
+        "stream-to-array": "~2.3.0"
+      }
+    },
+    "node_modules/stream-to-promise/node_modules/end-of-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
+      "integrity": "sha512-EoulkdKF/1xa92q25PbjuDcgJ9RDHYU2Rs3SCIvs2/dSQ3BpmxneNHmA/M7fe60M3PrV7nNGTTNbkK62l6vXiQ==",
+      "dev": true,
+      "dependencies": {
+        "once": "~1.3.0"
+      }
+    },
+    "node_modules/stream-to-promise/node_modules/once": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+      "integrity": "sha512-6vaNInhu+CHxtONf3zw3vq4SP2DOQhjBvIa3rNcG0+P7eKWlYH6Peu7rHizSloRU2EwMz6GraLieis9Ac9+p1w==",
+      "dev": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
@@ -53001,6 +54019,15 @@
         "tree-kill": "cli.js"
       }
     },
+    "node_modules/treeify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/treeify/-/treeify-1.1.0.tgz",
+      "integrity": "sha512-1m4RA7xVAJrSGrrXGs0L3YTwyvBs2S8PbRHaLZAkFw7JR8oIFwYtysxlBZhYIa7xSyiYJKZ3iGrrk55cGA3i9A==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/trim": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
@@ -53475,6 +54502,15 @@
       "version": "0.0.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/tunnel": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
+      }
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
@@ -55877,6 +56913,15 @@
       "version": "14.2.12",
       "requires": {
         "tslib": "^2.3.0"
+      }
+    },
+    "@arcanis/slice-ansi": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@arcanis/slice-ansi/-/slice-ansi-1.1.1.tgz",
+      "integrity": "sha512-xguP2WR2Dv0gQ7Ykbdb7BNCnPnIPB94uTi0Z2NvkRBEnhbwjOQ7QyQKJXrVQg4qDpiD9hA5l5cCwy/z2OXgc3w==",
+      "dev": true,
+      "requires": {
+        "grapheme-splitter": "^1.0.4"
       }
     },
     "@assemblyscript/loader": {
@@ -60838,6 +61883,12 @@
     "@sinclair/typebox": {
       "version": "0.24.51"
     },
+    "@sindresorhus/is": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
+      "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
+      "dev": true
+    },
     "@sinonjs/commons": {
       "version": "1.8.6",
       "requires": {
@@ -60848,6 +61899,56 @@
       "version": "9.1.2",
       "requires": {
         "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "@snyk/dep-graph": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@snyk/dep-graph/-/dep-graph-2.5.0.tgz",
+      "integrity": "sha512-wFKHAhsD1VBfESiuN2nHHeulEYAAod1Z4E/2t+ztsiJ5DCeD0pSXtJizdp2PhMZ0cFFce8ln3NO8xBhl+C4H+Q==",
+      "dev": true,
+      "requires": {
+        "event-loop-spinner": "^2.1.0",
+        "lodash.clone": "^4.5.0",
+        "lodash.constant": "^3.0.0",
+        "lodash.filter": "^4.6.0",
+        "lodash.foreach": "^4.5.0",
+        "lodash.isempty": "^4.4.0",
+        "lodash.isequal": "^4.5.0",
+        "lodash.isfunction": "^3.0.9",
+        "lodash.isundefined": "^3.0.1",
+        "lodash.map": "^4.6.0",
+        "lodash.reduce": "^4.6.0",
+        "lodash.size": "^4.2.0",
+        "lodash.transform": "^4.6.0",
+        "lodash.union": "^4.6.0",
+        "lodash.values": "^4.3.0",
+        "object-hash": "^3.0.0",
+        "packageurl-js": "^1.0.0",
+        "semver": "^7.0.0",
+        "tslib": "^2"
+      }
+    },
+    "@snyk/graphlib": {
+      "version": "2.1.9-patch.3",
+      "resolved": "https://registry.npmjs.org/@snyk/graphlib/-/graphlib-2.1.9-patch.3.tgz",
+      "integrity": "sha512-bBY9b9ulfLj0v2Eer0yFYa3syVeIxVKl2EpxSrsVeT4mjA0CltZyHsF0JjoaGXP27nItTdJS5uVsj1NA+3aE+Q==",
+      "dev": true,
+      "requires": {
+        "lodash.clone": "^4.5.0",
+        "lodash.constant": "^3.0.0",
+        "lodash.filter": "^4.6.0",
+        "lodash.foreach": "^4.5.0",
+        "lodash.has": "^4.5.2",
+        "lodash.isempty": "^4.4.0",
+        "lodash.isfunction": "^3.0.9",
+        "lodash.isundefined": "^3.0.1",
+        "lodash.keys": "^4.2.0",
+        "lodash.map": "^4.6.0",
+        "lodash.reduce": "^4.6.0",
+        "lodash.size": "^4.2.0",
+        "lodash.transform": "^4.6.0",
+        "lodash.union": "^4.6.0",
+        "lodash.values": "^4.3.0"
       }
     },
     "@storybook/addon-a11y": {
@@ -74504,6 +75605,15 @@
         }
       }
     },
+    "@szmarczak/http-timer": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
+      "integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
+      "dev": true,
+      "requires": {
+        "defer-to-connect": "^2.0.0"
+      }
+    },
     "@tootallnate/once": {
       "version": "2.0.0",
       "dev": true
@@ -74592,6 +75702,18 @@
         "@types/node": "*"
       }
     },
+    "@types/cacheable-request": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
+      "integrity": "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==",
+      "dev": true,
+      "requires": {
+        "@types/http-cache-semantics": "*",
+        "@types/keyv": "^3.1.4",
+        "@types/node": "*",
+        "@types/responselike": "^1.0.0"
+      }
+    },
     "@types/connect": {
       "version": "3.4.35",
       "requires": {
@@ -74604,6 +75726,12 @@
         "@types/express-serve-static-core": "*",
         "@types/node": "*"
       }
+    },
+    "@types/emscripten": {
+      "version": "1.39.6",
+      "resolved": "https://registry.npmjs.org/@types/emscripten/-/emscripten-1.39.6.tgz",
+      "integrity": "sha512-H90aoynNhhkQP6DRweEjJp5vfUVdIj7tdPLsu7pq89vODD/lcugKfZOsfgwpvM6XUewEp2N5dCg1Uf3Qe55Dcg==",
+      "dev": true
     },
     "@types/eslint": {
       "version": "8.4.10",
@@ -74663,6 +75791,12 @@
     "@types/html-minifier-terser": {
       "version": "6.1.0",
       "devOptional": true
+    },
+    "@types/http-cache-semantics": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz",
+      "integrity": "sha512-SZs7ekbP8CN0txVG2xVRH6EgKmEm31BOxA07vkFaETzZz1xh+cbt8BcI0slpymvwhx5dlFnQG2rTlPVQn+iRPQ==",
+      "dev": true
     },
     "@types/http-proxy": {
       "version": "1.17.9",
@@ -74789,6 +75923,15 @@
     "@types/json5": {
       "version": "0.0.29"
     },
+    "@types/keyv": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
+      "integrity": "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/lodash": {
       "version": "4.14.191",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.191.tgz",
@@ -74883,6 +76026,15 @@
         "@types/node": "*"
       }
     },
+    "@types/responselike": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.0.tgz",
+      "integrity": "sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/retry": {
       "version": "0.12.0"
     },
@@ -74941,6 +76093,12 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/tapable/-/tapable-1.0.8.tgz",
       "integrity": "sha512-ipixuVrh2OdNmauvtT51o3d8z12p6LtFW9in7U79der/kwejjdNchQC5UMn5u/KxNoM7VHHOs/l8KS8uHxhODQ==",
+      "dev": true
+    },
+    "@types/treeify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/treeify/-/treeify-1.0.0.tgz",
+      "integrity": "sha512-ONpcZAEYlbPx4EtJwfTyCDQJGUpKf4sEcuySdCVjK5Fj/3vHp5HII1fqa1/+qrsLnpYELCQTfVW/awsGJePoIg==",
       "dev": true
     },
     "@types/uglify-js": {
@@ -75428,6 +76586,190 @@
     "@xtuc/long": {
       "version": "4.2.2"
     },
+    "@yarnpkg/core": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/core/-/core-2.4.0.tgz",
+      "integrity": "sha512-FYjcPNTfDfMKLFafQPt49EY28jnYC82Z2S7oMwLPUh144BL8v8YXzb4aCnFyi5nFC5h2kcrJfZh7+Pm/qvCqGw==",
+      "dev": true,
+      "requires": {
+        "@arcanis/slice-ansi": "^1.0.2",
+        "@types/semver": "^7.1.0",
+        "@types/treeify": "^1.0.0",
+        "@yarnpkg/fslib": "^2.4.0",
+        "@yarnpkg/json-proxy": "^2.1.0",
+        "@yarnpkg/libzip": "^2.2.1",
+        "@yarnpkg/parsers": "^2.3.0",
+        "@yarnpkg/pnp": "^2.3.2",
+        "@yarnpkg/shell": "^2.4.1",
+        "binjumper": "^0.1.4",
+        "camelcase": "^5.3.1",
+        "chalk": "^3.0.0",
+        "ci-info": "^2.0.0",
+        "clipanion": "^2.6.2",
+        "cross-spawn": "7.0.3",
+        "diff": "^4.0.1",
+        "globby": "^11.0.1",
+        "got": "^11.7.0",
+        "json-file-plus": "^3.3.1",
+        "lodash": "^4.17.15",
+        "micromatch": "^4.0.2",
+        "mkdirp": "^0.5.1",
+        "p-limit": "^2.2.0",
+        "pluralize": "^7.0.0",
+        "pretty-bytes": "^5.1.0",
+        "semver": "^7.1.2",
+        "stream-to-promise": "^2.2.0",
+        "tar-stream": "^2.0.1",
+        "treeify": "^1.1.0",
+        "tslib": "^1.13.0",
+        "tunnel": "^0.0.6"
+      },
+      "dependencies": {
+        "@yarnpkg/parsers": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/@yarnpkg/parsers/-/parsers-2.5.1.tgz",
+          "integrity": "sha512-KtYN6Ez3x753vPF9rETxNTPnPjeaHY11Exlpqb4eTII7WRlnGiZ5rvvQBau4R20Ik5KBv+vS3EJEcHyCunwzzw==",
+          "dev": true,
+          "requires": {
+            "js-yaml": "^3.10.0",
+            "tslib": "^1.13.0"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "ci-info": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+          "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+          "dev": true
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.6",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+          "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.6"
+          }
+        },
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true
+        }
+      }
+    },
+    "@yarnpkg/fslib": {
+      "version": "2.10.2",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/fslib/-/fslib-2.10.2.tgz",
+      "integrity": "sha512-6WfQrPEV8QVpDPw5kd5s5jsb3QLqwVFSGZy3rEjl3p2FZ3OtIfYcLbFirOxXj2jXiKQDe7XbYsw1WjSf8K94gw==",
+      "dev": true,
+      "requires": {
+        "@yarnpkg/libzip": "^2.3.0",
+        "tslib": "^1.13.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true
+        }
+      }
+    },
+    "@yarnpkg/json-proxy": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/json-proxy/-/json-proxy-2.1.1.tgz",
+      "integrity": "sha512-meUiCAgCYpXTH1qJfqfz+dX013ohW9p2dKfwIzUYAFutH+lsz1eHPBIk72cuCV84adh9gX6j66ekBKH/bIhCQw==",
+      "dev": true,
+      "requires": {
+        "@yarnpkg/fslib": "^2.5.0",
+        "tslib": "^1.13.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true
+        }
+      }
+    },
+    "@yarnpkg/libzip": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/libzip/-/libzip-2.3.0.tgz",
+      "integrity": "sha512-6xm38yGVIa6mKm/DUCF2zFFJhERh/QWp1ufm4cNUvxsONBmfPg8uZ9pZBdOmF6qFGr/HlT6ABBkCSx/dlEtvWg==",
+      "dev": true,
+      "requires": {
+        "@types/emscripten": "^1.39.6",
+        "tslib": "^1.13.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true
+        }
+      }
+    },
     "@yarnpkg/lockfile": {
       "version": "1.1.0"
     },
@@ -75436,6 +76778,65 @@
       "requires": {
         "js-yaml": "^3.10.0",
         "tslib": "^2.4.0"
+      }
+    },
+    "@yarnpkg/pnp": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/pnp/-/pnp-2.3.2.tgz",
+      "integrity": "sha512-JdwHu1WBCISqJEhIwx6Hbpe8MYsYbkGMxoxolkDiAeJ9IGEe08mQcbX1YmUDV1ozSWlm9JZE90nMylcDsXRFpA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "^13.7.0",
+        "@yarnpkg/fslib": "^2.4.0",
+        "tslib": "^1.13.0"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "13.13.52",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.52.tgz",
+          "integrity": "sha512-s3nugnZumCC//n4moGGe6tkNMyYEdaDBitVjwPxXmR5lnMG5dHePinH2EdxkG3Rh1ghFHHixAG4NJhpJW1rthQ==",
+          "dev": true
+        },
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true
+        }
+      }
+    },
+    "@yarnpkg/shell": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/shell/-/shell-2.4.1.tgz",
+      "integrity": "sha512-oNNJkH8ZI5uwu0dMkJf737yMSY1WXn9gp55DqSA5wAOhKvV5DJTXFETxkVgBQhO6Bow9tMGSpvowTMD/oAW/9g==",
+      "dev": true,
+      "requires": {
+        "@yarnpkg/fslib": "^2.4.0",
+        "@yarnpkg/parsers": "^2.3.0",
+        "clipanion": "^2.6.2",
+        "cross-spawn": "7.0.3",
+        "fast-glob": "^3.2.2",
+        "micromatch": "^4.0.2",
+        "stream-buffers": "^3.0.2",
+        "tslib": "^1.13.0"
+      },
+      "dependencies": {
+        "@yarnpkg/parsers": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/@yarnpkg/parsers/-/parsers-2.5.1.tgz",
+          "integrity": "sha512-KtYN6Ez3x753vPF9rETxNTPnPjeaHY11Exlpqb4eTII7WRlnGiZ5rvvQBau4R20Ik5KBv+vS3EJEcHyCunwzzw==",
+          "dev": true,
+          "requires": {
+            "js-yaml": "^3.10.0",
+            "tslib": "^1.13.0"
+          }
+        },
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true
+        }
       }
     },
     "@zkochan/js-yaml": {
@@ -75670,6 +77071,12 @@
       "version": "0.1.0",
       "dev": true
     },
+    "any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true
+    },
     "anymatch": {
       "version": "3.1.3",
       "requires": {
@@ -75819,6 +77226,12 @@
     },
     "arrify": {
       "version": "3.0.0",
+      "dev": true
+    },
+    "asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
       "dev": true
     },
     "asn1": {
@@ -76442,6 +77855,12 @@
         "file-uri-to-path": "1.0.0"
       }
     },
+    "binjumper": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/binjumper/-/binjumper-0.1.4.tgz",
+      "integrity": "sha512-Gdxhj+U295tIM6cO4bJO1jsvSjBVHNpj2o/OwW7pqDEtaqF6KdOxjtbo93jMMKAkP7+u09+bV8DhSqjIv4qR3w==",
+      "dev": true
+    },
     "bl": {
       "version": "4.1.0",
       "requires": {
@@ -76839,6 +78258,38 @@
         "unset-value": "^1.0.0"
       }
     },
+    "cacheable-lookup": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
+      "integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
+      "dev": true
+    },
+    "cacheable-request": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.2.tgz",
+      "integrity": "sha512-pouW8/FmiPQbuGpkXQ9BAPv/Mo5xDGANgSNXzTzJ8DrKGuXOssM4wIQRjfanNRh3Yu5cfYPvcorqbhg2KIJtew==",
+      "dev": true,
+      "requires": {
+        "clone-response": "^1.0.2",
+        "get-stream": "^5.1.0",
+        "http-cache-semantics": "^4.0.0",
+        "keyv": "^4.0.0",
+        "lowercase-keys": "^2.0.0",
+        "normalize-url": "^6.0.1",
+        "responselike": "^2.0.0"
+      },
+      "dependencies": {
+        "get-stream": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+          "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        }
+      }
+    },
     "cachedir": {
       "version": "2.3.0",
       "devOptional": true
@@ -77029,6 +78480,17 @@
       "version": "2.0.0",
       "dev": true
     },
+    "chromatic": {
+      "version": "6.17.2",
+      "resolved": "https://registry.npmjs.org/chromatic/-/chromatic-6.17.2.tgz",
+      "integrity": "sha512-rtrkywh1CuDDuuiRWXpdiX38aEGN3sGCATsgdh3X/EUBjQjgQtEbSzcMusC3cqz3K9dFKcWwKpFm3jaw9gNymA==",
+      "dev": true,
+      "requires": {
+        "@discoveryjs/json-ext": "^0.5.7",
+        "@types/webpack-env": "^1.17.0",
+        "snyk-nodejs-lockfile-parser": "^1.47.4"
+      }
+    },
     "chrome-trace-event": {
       "version": "1.0.3"
     },
@@ -77160,6 +78622,12 @@
       "version": "3.0.0",
       "dev": true
     },
+    "clipanion": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/clipanion/-/clipanion-2.6.2.tgz",
+      "integrity": "sha512-0tOHJNMF9+4R3qcbBL+4IxLErpaYSYvzs10aXuECDbZdJOuJHdagJMAqvLdeaUQTI/o2uSCDRpet6ywDiKOAYw==",
+      "dev": true
+    },
     "cliui": {
       "version": "7.0.4",
       "requires": {
@@ -77177,6 +78645,15 @@
         "is-plain-object": "^2.0.4",
         "kind-of": "^6.0.2",
         "shallow-clone": "^3.0.0"
+      }
+    },
+    "clone-response": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
+      "integrity": "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==",
+      "dev": true,
+      "requires": {
+        "mimic-response": "^1.0.0"
       }
     },
     "co": {
@@ -78630,6 +80107,23 @@
     "decode-uri-component": {
       "version": "0.2.2"
     },
+    "decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "dev": true,
+      "requires": {
+        "mimic-response": "^3.1.0"
+      },
+      "dependencies": {
+        "mimic-response": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+          "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+          "dev": true
+        }
+      }
+    },
     "dedent": {
       "version": "0.7.0"
     },
@@ -78853,6 +80347,12 @@
       "requires": {
         "clone": "^1.0.2"
       }
+    },
+    "defer-to-connect": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
+      "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
+      "dev": true
     },
     "define-lazy-prop": {
       "version": "2.0.0"
@@ -79778,6 +81278,15 @@
       "requires": {
         "d": "1",
         "es5-ext": "~0.10.14"
+      }
+    },
+    "event-loop-spinner": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/event-loop-spinner/-/event-loop-spinner-2.2.0.tgz",
+      "integrity": "sha512-KB44sV4Mv7uLIkJHJ5qhiZe5um6th2g57nHQL/uqnPHKP2IswoTRWUteEXTJQL4gW++1zqWUni+H2hGkP51c9w==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.1.0"
       }
     },
     "event-stream": {
@@ -81181,8 +82690,33 @@
         "get-intrinsic": "^1.1.3"
       }
     },
+    "got": {
+      "version": "11.8.6",
+      "resolved": "https://registry.npmjs.org/got/-/got-11.8.6.tgz",
+      "integrity": "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==",
+      "dev": true,
+      "requires": {
+        "@sindresorhus/is": "^4.0.0",
+        "@szmarczak/http-timer": "^4.0.5",
+        "@types/cacheable-request": "^6.0.1",
+        "@types/responselike": "^1.0.0",
+        "cacheable-lookup": "^5.0.3",
+        "cacheable-request": "^7.0.2",
+        "decompress-response": "^6.0.0",
+        "http2-wrapper": "^1.0.0-beta.5.2",
+        "lowercase-keys": "^2.0.0",
+        "p-cancelable": "^2.0.0",
+        "responselike": "^2.0.0"
+      }
+    },
     "graceful-fs": {
       "version": "4.2.10"
+    },
+    "grapheme-splitter": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
+      "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
+      "dev": true
     },
     "handle-thing": {
       "version": "2.0.1"
@@ -81707,6 +83241,24 @@
         "sshpk": "^1.14.1"
       }
     },
+    "http2-wrapper": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
+      "integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
+      "dev": true,
+      "requires": {
+        "quick-lru": "^5.1.1",
+        "resolve-alpn": "^1.0.0"
+      },
+      "dependencies": {
+        "quick-lru": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+          "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+          "dev": true
+        }
+      }
+    },
     "https-browserify": {
       "version": "1.0.0",
       "dev": true
@@ -81970,6 +83522,12 @@
     },
     "ipaddr.js": {
       "version": "1.9.1"
+    },
+    "is": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/is/-/is-3.3.0.tgz",
+      "integrity": "sha512-nW24QBoPcFGGHJGUwnfpI7Yc5CdqWNdsyHQszVE/z2pKHXzh7FZ5GWhJqSyaQ9wMkQnsTx+kAI8bHlCX4tKdbg==",
+      "dev": true
     },
     "is-absolute-url": {
       "version": "3.0.3",
@@ -85229,6 +86787,25 @@
     "jsesc": {
       "version": "2.5.2"
     },
+    "json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true
+    },
+    "json-file-plus": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/json-file-plus/-/json-file-plus-3.3.1.tgz",
+      "integrity": "sha512-wo0q1UuiV5NsDPQDup1Km8IwEeqe+olr8tkWxeJq9Bjtcp7DZ0l+yrg28fSC3DEtrE311mhTZ54QGS6oiqnZEA==",
+      "dev": true,
+      "requires": {
+        "is": "^3.2.1",
+        "node.extend": "^2.0.0",
+        "object.assign": "^4.1.0",
+        "promiseback": "^2.0.2",
+        "safer-buffer": "^2.0.2"
+      }
+    },
     "json-parse-better-errors": {
       "version": "1.0.2",
       "dev": true
@@ -85295,6 +86872,15 @@
       "dev": true,
       "requires": {
         "source-map-support": "^0.5.5"
+      }
+    },
+    "keyv": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.2.tgz",
+      "integrity": "sha512-5MHbFaKn8cNSmVW7BYnijeAVlE4cYA/SVkifVgrh7yotnfhKmjuXpDKjrABLnT0SfHWV21P8ow07OGfRrNDg8g==",
+      "dev": true,
+      "requires": {
+        "json-buffer": "3.0.1"
       }
     },
     "kind-of": {
@@ -85449,8 +87035,68 @@
     "lodash.camelcase": {
       "version": "4.3.0"
     },
+    "lodash.clone": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clone/-/lodash.clone-4.5.0.tgz",
+      "integrity": "sha512-GhrVeweiTD6uTmmn5hV/lzgCQhccwReIVRLHp7LT4SopOjqEZ5BbX8b5WWEtAKasjmy8hR7ZPwsYlxRCku5odg==",
+      "dev": true
+    },
+    "lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
+      "dev": true
+    },
+    "lodash.constant": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.constant/-/lodash.constant-3.0.0.tgz",
+      "integrity": "sha512-X5XMrB+SdI1mFa81162NSTo/YNd23SLdLOLzcXTwS4inDZ5YCL8X67UFzZJAH4CqIa6R8cr56CShfA5K5MFiYQ==",
+      "dev": true
+    },
     "lodash.debounce": {
       "version": "4.0.8"
+    },
+    "lodash.filter": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.filter/-/lodash.filter-4.6.0.tgz",
+      "integrity": "sha512-pXYUy7PR8BCLwX5mgJ/aNtyOvuJTdZAo9EQFUvMIYugqmJxnrYaANvTbgndOzHSCSR0wnlBBfRXJL5SbWxo3FQ==",
+      "dev": true
+    },
+    "lodash.flatmap": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.flatmap/-/lodash.flatmap-4.5.0.tgz",
+      "integrity": "sha512-/OcpcAGWlrZyoHGeHh3cAoa6nGdX6QYtmzNP84Jqol6UEQQ2gIaU3H+0eICcjcKGl0/XF8LWOujNn9lffsnaOg==",
+      "dev": true
+    },
+    "lodash.foreach": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-4.5.0.tgz",
+      "integrity": "sha512-aEXTF4d+m05rVOAUG3z4vZZ4xVexLKZGF0lIxuHZ1Hplpk/3B6Z1+/ICICYRLm7c41Z2xiejbkCkJoTlypoXhQ==",
+      "dev": true
+    },
+    "lodash.has": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/lodash.has/-/lodash.has-4.5.2.tgz",
+      "integrity": "sha512-rnYUdIo6xRCJnQmbVFEwcxF144erlD+M3YcJUVesflU9paQaE8p+fJDcIQrlMYbxoANFL+AB9hZrzSBBk5PL+g==",
+      "dev": true
+    },
+    "lodash.isempty": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.isempty/-/lodash.isempty-4.4.0.tgz",
+      "integrity": "sha512-oKMuF3xEeqDltrGMfDxAPGIVMSSRv8tbRSODbrs4KGsRRLEhrW8N8Rd4DRgB2+621hY8A8XwwrTVhXWpxFvMzg==",
+      "dev": true
+    },
+    "lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "dev": true
+    },
+    "lodash.isfunction": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz",
+      "integrity": "sha512-AirXNj15uRIMMPihnkInB4i3NHeb4iBtNg9WRWuK2o31S+ePwwNmDPaTL3o7dTJ+VXNZim7rFs4rxN4YU1oUJw==",
+      "dev": true
     },
     "lodash.ismatch": {
       "version": "4.4.0",
@@ -85460,8 +87106,26 @@
       "version": "4.0.6",
       "dev": true
     },
+    "lodash.isundefined": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isundefined/-/lodash.isundefined-3.0.1.tgz",
+      "integrity": "sha512-MXB1is3s899/cD8jheYYE2V9qTHwKvt+npCwpD+1Sxm3Q3cECXCiYHjeHWXNwr6Q0SOBPrYUDxendrO6goVTEA==",
+      "dev": true
+    },
     "lodash.kebabcase": {
       "version": "4.1.1"
+    },
+    "lodash.keys": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-4.2.0.tgz",
+      "integrity": "sha512-J79MkJcp7Df5mizHiVNpjoHXLi4HLjh9VLS/M7lQSGoQ+0oQ+lWEigREkqKyizPB1IawvQLLKY8mzEcm1tkyxQ==",
+      "dev": true
+    },
+    "lodash.map": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.map/-/lodash.map-4.6.0.tgz",
+      "integrity": "sha512-worNHGKLDetmcEYDvh2stPCrrQRkP20E4l0iIS7F8EvzMqBBi7ltvFN5m1HvTf1P7Jk1txKhvFcmYsCr8O2F1Q==",
+      "dev": true
     },
     "lodash.memoize": {
       "version": "4.1.2"
@@ -85478,6 +87142,18 @@
       "version": "4.1.1",
       "devOptional": true
     },
+    "lodash.reduce": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.reduce/-/lodash.reduce-4.6.0.tgz",
+      "integrity": "sha512-6raRe2vxCYBhpBu+B+TtNGUzah+hQjVdu3E17wfusjyrXBka2nBS8OH/gjVZ5PvHOhWmIZTYri09Z6n/QfnNMw==",
+      "dev": true
+    },
+    "lodash.size": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.size/-/lodash.size-4.2.0.tgz",
+      "integrity": "sha512-wbu3SF1XC5ijqm0piNxw59yCbuUf2kaShumYBLWUrcCvwh6C8odz6SY/wGVzCWTQTFL/1Ygbvqg2eLtspUVVAQ==",
+      "dev": true
+    },
     "lodash.snakecase": {
       "version": "4.1.1"
     },
@@ -85485,8 +87161,26 @@
       "version": "4.4.0",
       "dev": true
     },
+    "lodash.topairs": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.topairs/-/lodash.topairs-4.3.0.tgz",
+      "integrity": "sha512-qrRMbykBSEGdOgQLJJqVSdPWMD7Q+GJJ5jMRfQYb+LTLsw3tYVIabnCzRqTJb2WTo17PG5gNzXuFaZgYH/9SAQ==",
+      "dev": true
+    },
+    "lodash.transform": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.transform/-/lodash.transform-4.6.0.tgz",
+      "integrity": "sha512-LO37ZnhmBVx0GvOU/caQuipEh4GN82TcWv3yHlebGDgOxbxiwwzW5Pcx2AcvpIv2WmvmSMoC492yQFNhy/l/UQ==",
+      "dev": true
+    },
     "lodash.truncate": {
       "version": "4.4.2",
+      "dev": true
+    },
+    "lodash.union": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
+      "integrity": "sha512-c4pB2CdGrGdjMKYLA+XiRDO7Y0PRQbm/Gzg8qMj+QH+pFVAoTp5sBpO0odL3FjoPCGjK96p6qsP+yQoiLoOBcw==",
       "dev": true
     },
     "lodash.uniq": {
@@ -85494,6 +87188,12 @@
     },
     "lodash.upperfirst": {
       "version": "4.3.1",
+      "dev": true
+    },
+    "lodash.values": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.values/-/lodash.values-4.3.0.tgz",
+      "integrity": "sha512-r0RwvdCv8id9TUblb/O7rYPwVy6lerCbcawrfdo9iC/1t1wsNMJknO79WNBgwkH0hIeJ08jmvvESbFpNb4jH0Q==",
       "dev": true
     },
     "log-symbols": {
@@ -85614,6 +87314,12 @@
       "requires": {
         "tslib": "^2.0.3"
       }
+    },
+    "lowercase-keys": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+      "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+      "dev": true
     },
     "lowlight": {
       "version": "1.20.0",
@@ -85955,6 +87661,12 @@
     },
     "mimic-fn": {
       "version": "2.1.0"
+    },
+    "mimic-response": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+      "dev": true
     },
     "min-document": {
       "version": "2.19.0",
@@ -86641,6 +88353,16 @@
     "node-releases": {
       "version": "2.0.6"
     },
+    "node.extend": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/node.extend/-/node.extend-2.0.2.tgz",
+      "integrity": "sha512-pDT4Dchl94/+kkgdwyS2PauDFjZG0Hk0IcHIB+LkW27HLDtdoeMxHTxZh39DYbPP8UflWXWj9JcdDozF+YDOpQ==",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.3",
+        "is": "^3.2.1"
+      }
+    },
     "nopt": {
       "version": "6.0.0",
       "dev": true,
@@ -86978,6 +88700,12 @@
         }
       }
     },
+    "object-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "dev": true
+    },
     "object-inspect": {
       "version": "1.12.2"
     },
@@ -87190,6 +88918,12 @@
         }
       }
     },
+    "p-cancelable": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
+      "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
+      "dev": true
+    },
     "p-defer": {
       "version": "1.0.0",
       "dev": true
@@ -87285,6 +89019,12 @@
     },
     "p-try": {
       "version": "2.2.0"
+    },
+    "packageurl-js": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/packageurl-js/-/packageurl-js-1.0.1.tgz",
+      "integrity": "sha512-EtXC0kgLjy/C7S4SN3Kk1SDRWLzIn/LUK0gXlz3gsxDdpI0k7q8C3SASpV0pc+v0yADBTt5rWewq/flGdGxtoQ==",
+      "dev": true
     },
     "pacote": {
       "version": "13.6.2",
@@ -87586,6 +89326,12 @@
       "requires": {
         "find-up": "^5.0.0"
       }
+    },
+    "pluralize": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
+      "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
+      "dev": true
     },
     "png-js": {
       "version": "1.0.0",
@@ -88306,6 +90052,24 @@
     "process-nextick-args": {
       "version": "2.0.1"
     },
+    "promise": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+      "dev": true,
+      "requires": {
+        "asap": "~2.0.3"
+      }
+    },
+    "promise-deferred": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/promise-deferred/-/promise-deferred-2.0.3.tgz",
+      "integrity": "sha512-n10XaoznCzLfyPFOlEE8iurezHpxrYzyjgq/1eW9Wk1gJwur/N7BdBmjJYJpqMeMcXK4wEbzo2EvZQcqjYcKUQ==",
+      "dev": true,
+      "requires": {
+        "promise": "^7.3.1"
+      }
+    },
     "promise-inflight": {
       "version": "1.0.1",
       "dev": true
@@ -88337,6 +90101,16 @@
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.4",
         "es-abstract": "^1.20.4"
+      }
+    },
+    "promiseback": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/promiseback/-/promiseback-2.0.3.tgz",
+      "integrity": "sha512-VZXdCwS0ppVNTIRfNsCvVwJAaP2b+pxQF7lM8DMWfmpNWyTxB6O5YNbzs+8z0ki/KIBHKHk308NTIl4kJUem3w==",
+      "dev": true,
+      "requires": {
+        "is-callable": "^1.1.5",
+        "promise-deferred": "^2.0.3"
       }
     },
     "prompts": {
@@ -89116,6 +90890,12 @@
         "supports-preserve-symlinks-flag": "^1.0.0"
       }
     },
+    "resolve-alpn": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
+      "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
+      "dev": true
+    },
     "resolve-cwd": {
       "version": "3.0.0",
       "dev": true,
@@ -89178,6 +90958,15 @@
     },
     "resolve.exports": {
       "version": "1.1.0"
+    },
+    "responselike": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
+      "integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
+      "dev": true,
+      "requires": {
+        "lowercase-keys": "^2.0.0"
+      }
     },
     "restore-cursor": {
       "version": "3.1.0",
@@ -90037,6 +91826,70 @@
         }
       }
     },
+    "snyk-config": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/snyk-config/-/snyk-config-5.1.0.tgz",
+      "integrity": "sha512-wqVMxUGqjjHX+MJrz0WHa/pJTDWU17aRv6cnI/6i7cq93J3TkkJZ8sjgvwCgP8cWX5wTHIlRuMV+IAd59K4X/g==",
+      "dev": true,
+      "requires": {
+        "async": "^3.2.0",
+        "debug": "^4.1.1",
+        "lodash.merge": "^4.6.2",
+        "minimist": "^1.2.5"
+      }
+    },
+    "snyk-nodejs-lockfile-parser": {
+      "version": "1.48.0",
+      "resolved": "https://registry.npmjs.org/snyk-nodejs-lockfile-parser/-/snyk-nodejs-lockfile-parser-1.48.0.tgz",
+      "integrity": "sha512-kq4gVwL5V0SUatDxyyzbptKkaX4Ew9N3ZDNR5r7sqBRparY+U+xGuYBhTaJdweBUD+jkvs7rKO1JV1h0Z8c2ew==",
+      "dev": true,
+      "requires": {
+        "@snyk/dep-graph": "^2.3.0",
+        "@snyk/graphlib": "2.1.9-patch.3",
+        "@yarnpkg/core": "^2.4.0",
+        "@yarnpkg/lockfile": "^1.1.0",
+        "event-loop-spinner": "^2.0.0",
+        "js-yaml": "^4.1.0",
+        "lodash.clonedeep": "^4.5.0",
+        "lodash.flatmap": "^4.5.0",
+        "lodash.isempty": "^4.4.0",
+        "lodash.topairs": "^4.3.0",
+        "micromatch": "^4.0.5",
+        "semver": "^7.3.5",
+        "snyk-config": "^5.0.0",
+        "tslib": "^1.9.3",
+        "uuid": "^8.3.0"
+      },
+      "dependencies": {
+        "argparse": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+          "dev": true
+        },
+        "js-yaml": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+          "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+          "dev": true,
+          "requires": {
+            "argparse": "^2.0.1"
+          }
+        },
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true
+        },
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+          "dev": true
+        }
+      }
+    },
     "sockjs": {
       "version": "0.3.24",
       "requires": {
@@ -90567,6 +92420,12 @@
         }
       }
     },
+    "stream-buffers": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-3.0.2.tgz",
+      "integrity": "sha512-DQi1h8VEBA/lURbSwFtEHnSTb9s2/pwLEaFuNhXwy1Dx3Sa0lOuYT2yNUr4/j2fs8oCAMANtrZ5OrPZtyVs3MQ==",
+      "dev": true
+    },
     "stream-combiner": {
       "version": "0.2.2",
       "dev": true,
@@ -90623,6 +92482,46 @@
     "stream-shift": {
       "version": "1.0.1",
       "dev": true
+    },
+    "stream-to-array": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/stream-to-array/-/stream-to-array-2.3.0.tgz",
+      "integrity": "sha512-UsZtOYEn4tWU2RGLOXr/o/xjRBftZRlG3dEWoaHr8j4GuypJ3isitGbVyjQKAuMu+xbiop8q224TjiZWc4XTZA==",
+      "dev": true,
+      "requires": {
+        "any-promise": "^1.1.0"
+      }
+    },
+    "stream-to-promise": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/stream-to-promise/-/stream-to-promise-2.2.0.tgz",
+      "integrity": "sha512-HAGUASw8NT0k8JvIVutB2Y/9iBk7gpgEyAudXwNJmZERdMITGdajOa4VJfD/kNiA3TppQpTP4J+CtcHwdzKBAw==",
+      "dev": true,
+      "requires": {
+        "any-promise": "~1.3.0",
+        "end-of-stream": "~1.1.0",
+        "stream-to-array": "~2.3.0"
+      },
+      "dependencies": {
+        "end-of-stream": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
+          "integrity": "sha512-EoulkdKF/1xa92q25PbjuDcgJ9RDHYU2Rs3SCIvs2/dSQ3BpmxneNHmA/M7fe60M3PrV7nNGTTNbkK62l6vXiQ==",
+          "dev": true,
+          "requires": {
+            "once": "~1.3.0"
+          }
+        },
+        "once": {
+          "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+          "integrity": "sha512-6vaNInhu+CHxtONf3zw3vq4SP2DOQhjBvIa3rNcG0+P7eKWlYH6Peu7rHizSloRU2EwMz6GraLieis9Ac9+p1w==",
+          "dev": true,
+          "requires": {
+            "wrappy": "1"
+          }
+        }
+      }
     },
     "string_decoder": {
       "version": "1.3.0",
@@ -91777,6 +93676,12 @@
     "tree-kill": {
       "version": "1.2.2"
     },
+    "treeify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/treeify/-/treeify-1.1.0.tgz",
+      "integrity": "sha512-1m4RA7xVAJrSGrrXGs0L3YTwyvBs2S8PbRHaLZAkFw7JR8oIFwYtysxlBZhYIa7xSyiYJKZ3iGrrk55cGA3i9A==",
+      "dev": true
+    },
     "trim": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
@@ -92055,6 +93960,12 @@
     },
     "tty-browserify": {
       "version": "0.0.0",
+      "dev": true
+    },
+    "tunnel": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
       "dev": true
     },
     "tunnel-agent": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "publish:styles": "npm publish dist/libs/styles",
     "publish:ui": "npm publish dist/libs/ui",
     "publish:icons": "npm publish dist/libs/icons",
-    "cy:ui": "npx cypress open --project=apps/ui-e2e"
+    "cy:ui": "npx cypress open --project=apps/ui-e2e",
+    "chromatic": "chromatic --exit-zero-on-changes --project-token=23c52c9242eb"
   },
   "private": true,
   "dependencies": {
@@ -86,6 +87,7 @@
     "@typescript-eslint/eslint-plugin": "5.45.0",
     "@typescript-eslint/parser": "5.45.0",
     "@whitespace/storybook-addon-html": "^5.0.0",
+    "chromatic": "^6.17.2",
     "cpy-cli": "^4.2.0",
     "cypress": "10.8.0",
     "cypress-storybook": "^0.5.1",


### PR DESCRIPTION
The screenshot testing is possible thanks to the open source sponsorship by Chromatic. 

The action always passes (even when visual changes are detected) except for cases when a story is broken. However we expect contributors and reviewers to check the results of the action (and accept or decline them in the Chromatic UI) by following a link in the build log. 

Right now it runs on `push`, because running it on `pull-request` and blocking a PR needs more repo permissions anyway. 

The Chromatic secret key is exposed 2 times – in `package.json` since it should help with testing in [forked repos](https://www.chromatic.com/docs/github-actions#forked-repositories), and in `chromatic.yml` because we can't run the Github action without it and we have no rights yet for adding a secret to the repo as an environment variable. 

