### PR TITLE
fix(github): removed a reserved 'None' word from Feature request issue template that broke it

### DIFF
--- a/.github/ISSUE_TEMPLATE/FEATURE-REQUEST.yml
+++ b/.github/ISSUE_TEMPLATE/FEATURE-REQUEST.yml
@@ -24,7 +24,7 @@ body:
       label: Does this feature request involve any updates to the reference design?
       description: Indicate whether your proposed changes conform to the existing design system or assume it needs to be modified too.
       options:
-        - 'None'
+        - 'No'
         - 'Yes'
         - 'Not applicable'
     validations:


### PR DESCRIPTION
See https://docs.github.com/en/enterprise-cloud@latest/communities/using-templates-to-encourage-useful-issues-and-pull-requests/common-validation-errors-when-creating-issue-forms#bodyi-options-must-not-include-the-reserved-word-none