### PR TITLE
fix(docs): added quick installation instructions to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@ This repository includes a shared CSS library (preprocessed with Sass) and HTML 
 By design, the CSS has no dependency on a specific Javascript framework and since the styles and html is separated then interested contributors can easily add component libraries in other frameworks such as React or Vue.js.
 Also, the Angular UI library has no dependency to any design system/framework such as Bootstrap or Google's Material in order to reduce dependence on 3rd party vendors.
 
-## Quick Start & Documentation
+## Quick Start & documentation
 
-The pattern library uses [Storybook](https://storybook.js.org)
+Both CSS framework and Angular component library use [Storybook](https://storybook.js.org).
 
-Documentation and Installation instructions can be found in the e-Gov CVI's Storybook:
+Documentation and installation instructions can be viewed in the e-Gov CVI's Storybook:
 
-[https://e-gov.github.io/cvi/](https://e-gov.github.io/cvi/)
+[https://e-gov.github.io/cvi/](https://e-gov.github.io/cvi/).
 
 Styles were based on the initial Veera Design System:
 
@@ -21,15 +21,20 @@ But please take note that e-Gov CVI **is not Veera**.
 
 ### Installation
 
-Run `npm install` in the root folder.
+1. Add the public Koodivaramu registry to your project by following the instructions [here](https://koodivaramu.eesti.ee/e-gov/cvi/-/packages/385).
+2. Install the necessary package to your project:
+   1. CSS framework: `npm i --save @egov/cvi-styles`
+   2. Angular components: `npm i --save @egov/cvi-ng`
+   3. Icons: `npm i --save @egov/cvi-icons`
+3. Import the dependencies to your project by following dedicated instructions in the docs for the [CSS framework](https://e-gov.github.io/cvi/?path=/docs/styles-how-to-install--how-to-install), [Angular components](https://e-gov.github.io/cvi/?path=/docs/angular-installation--installation), and [icons](https://e-gov.github.io/cvi/?path=/docs/icons-how-to-use--page).
 
-## Using the Components
+## Packages and artifacts repository
 
 The built packages are published to the public Koodivaramu repository, from where you can download and add them to your application:
 
 https://koodivaramu.eesti.ee/e-gov/cvi/-/packages
 
-In addition, the storybook docker image is also published to the Koodivaramu repository:
+In addition, the Storybook Docker image is also published to the Koodivaramu repository:
 
 https://koodivaramu.eesti.ee/e-gov/cvi/container_registry
 
@@ -58,12 +63,14 @@ For example, if you need to introduce a content selector that inserts custom con
 
 Run `npm run storybook` to build documentation and run the Storybook locally.
 
-### Running storybook locally in docker
+### Running Storybook locally in Docker
 
+```
 docker build -f ./libs/storybook/Dockerfile -t cvi-storybook .
 docker-compose up storybook
 docker-compose down
 url: http://localhost:3005/
+```
 
 ## Understand your workspace
 

--- a/libs/storybook/src/lib/stories/angular.stories.mdx
+++ b/libs/storybook/src/lib/stories/angular.stories.mdx
@@ -33,10 +33,10 @@ import uiPkg from '/libs/ui/package.json'
 
 1. Install the library
 ```
-npm i --save @egov/cvi-ng;
+npm i --save @egov/cvi-ng
 ```
 
-2. Import UiModule in your app.module.ts.
+2. Import `UiModule` in your `app.module.ts`.
 
 ```ts
 import { UiModule } from '@egov/cvi-ng';

--- a/libs/storybook/src/lib/stories/styles/installation.stories.mdx
+++ b/libs/storybook/src/lib/stories/styles/installation.stories.mdx
@@ -25,7 +25,7 @@ The library styles are built using Sass (namely [Dart Sass](https://sass-lang.co
     ```
 2. Include styles to a Sass file in the project:
     ```
-    @use '@egov/cvi-styles';
+    @use '@egov/cvi-styles/main';
     ```
 
 You can also `@use` or `@import` a specific Sass module from the library, eg. `@use '@egov/cvi-styles/settings/variables/typography';`.


### PR DESCRIPTION
The README lacked a mention of adding a custom package repository URL to `.npmrc`.