### PR TITLE
fix(all): changed npm run test command to launch ui project tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "postinstall": "node ./decorate-angular-cli.js && ngcc --properties es2020 browser module main",
     "start": "nx serve",
     "build": "nx build",
-    "test": "npx nx run ui:test",
+    "test": "nx run ui:test",
     "lint:all": "nx workspace-lint && nx run-many --target=lint --all",
     "lint:css": "npx stylelint ./libs/styles/src/lib/scss/*.scss",
     "lint:svg": "svglint ./libs/icons/src/lib/svg/*.svg --ci",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "postinstall": "node ./decorate-angular-cli.js && ngcc --properties es2020 browser module main",
     "start": "nx serve",
     "build": "nx build",
-    "test": "nx test",
+    "test": "npx nx run ui:test",
     "lint:all": "nx workspace-lint && nx run-many --target=lint --all",
     "lint:css": "npx stylelint ./libs/styles/src/lib/scss/*.scss",
     "lint:svg": "svglint ./libs/icons/src/lib/svg/*.svg --ci",


### PR DESCRIPTION
Changed `npm run test` command to launch ui project tests instead of ria project tests (which do not exist).

Fixes #74.