### PR TITLE
feat(styles): added ability to import styles only by package name

### DIFF
--- a/libs/storybook/src/lib/stories/styles/installation.stories.mdx
+++ b/libs/storybook/src/lib/stories/styles/installation.stories.mdx
@@ -23,9 +23,9 @@ The library styles are built using Sass (namely [Dart Sass](https://sass-lang.co
     ```
     npm i --save @egov/cvi-styles
     ```
-2. Include styles to a Sass file in the project:
+2. Import CVI styles to a Sass file in your project:
     ```
-    @use '@egov/cvi-styles/main';
+    @use '@egov/cvi-styles';
     ```
 
 You can also `@use` or `@import` a specific Sass module from the library, eg. `@use '@egov/cvi-styles/settings/variables/typography';`.

--- a/libs/styles/package.json
+++ b/libs/styles/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@egov/cvi-styles",
   "version": "1.6.0",
+  "main": "main.scss",
   "dependencies": {
     "tslib": "^2.3.0",
     "@fontsource/roboto": "^4.5.8"


### PR DESCRIPTION
Fixes #79.

NB: could be incompatible with #81 because we may want to have a CSS file served as a main entry point, not a Sass file.