### PR TITLE
feat(ui): added a new default value to horizontalAlignment prop of cvi-ng-track

### DIFF
--- a/libs/ui/src/lib/track/track.component.md
+++ b/libs/ui/src/lib/track/track.component.md
@@ -11,6 +11,4 @@ Permitted children | any
 
 ## Where to use
 
-Use with multiple children to provide a flex- or grid-like layout and ensure and equal gaps between them consistent to the design system.
-
-This utility component packages CSS flex layout technique to serve as a quick layout helper, but it is perfectly fine to use `display: flex` directly in your styles too.
+A a quick layout helper. Use with multiple children to provide a flex- or grid-like layout and ensure gaps between them are consistent with the design system.

--- a/libs/ui/src/lib/track/track.component.stories.ts
+++ b/libs/ui/src/lib/track/track.component.stories.ts
@@ -28,7 +28,7 @@ export default {
     },
     horizontalAlignment: {
       name: 'Horizontal alignment',
-      options: ['left', 'center', 'right', 'justify'],
+      options: ['normal', 'left', 'center', 'right', 'justify'],
       control: { type: 'inline-radio' },
       if: { arg: 'flexDirection', eq: 'horizontal' },
     },
@@ -73,7 +73,7 @@ export default {
   },
   args: {
     gap: 1,
-    horizontalAlignment: 'left',
+    horizontalAlignment: 'normal',
     verticalAlignment: 'normal',
     flexDirection: 'horizontal',
     layout: 'flex',

--- a/libs/ui/src/lib/track/track.component.stories.ts
+++ b/libs/ui/src/lib/track/track.component.stories.ts
@@ -94,6 +94,21 @@ const Template: Story<TrackComponent> = (args: TrackComponent) => ({
   `,
 });
 
+const TemplateNestedTracks: Story<TrackComponent> = (args: TrackComponent) => ({
+  props: args,
+  /* template */
+  template: `
+    <cvi-ng-storybook-note>This story is to verify a bug where a nested track  with <code>horizontalAlignment=left</code> can't override the same prop of an ancestor track.<br>Here, the parent track is set to <code>right</code> and nested track to <code>left</code>. However, due to the bug the nested track still aligns to right.</cvi-ng-storybook-note>
+    <cvi-ng-track [gap]="gap" [horizontalAlignment]="horizontalAlignment" [verticalAlignment]="verticalAlignment" [flexDirection]="flexDirection" [flexIsMultiline]="flexIsMultiline" [layout]="layout">
+      <div>Item 1</div>
+      <cvi-ng-track [gap]="2" horizontalAlignment="left">
+        <div>Nested track with <code>horizontalAlignment="left"</code>: Item 2.1<br>And some filler easy view fifty tell string park its easier large read help ship younger rising gate hundred silk policeman dear hidden powerful table further mission</div>
+        <div>Nested track: Item 2.2</div>
+      </cvi-ng-track>
+    </cvi-ng-track>
+  `,
+});
+
 const TemplateManyItems: Story<TrackComponent> = (args: TrackComponent) => ({
   props: args,
   /* template */
@@ -239,6 +254,12 @@ VerticalReverseMobileOnlyMobile.parameters = {
   viewport: {
     defaultViewport: 'iphone12mini',
   },
+};
+
+export const NestedTracks = TemplateNestedTracks.bind({});
+NestedTracks.args = {
+  horizontalAlignment: 'right',
+  flexIsMultiline: true,
 };
 
 export const Multiline = TemplateManyItems.bind({});

--- a/libs/ui/src/lib/track/track.component.stories.ts
+++ b/libs/ui/src/lib/track/track.component.stories.ts
@@ -98,7 +98,7 @@ const TemplateNestedTracks: Story<TrackComponent> = (args: TrackComponent) => ({
   props: args,
   /* template */
   template: `
-    <cvi-ng-storybook-note>This story is to verify a bug where a nested track  with <code>horizontalAlignment=left</code> can't override the same prop of an ancestor track.<br>Here, the parent track is set to <code>right</code> and nested track to <code>left</code>. However, due to the bug the nested track still aligns to right.</cvi-ng-storybook-note>
+    <cvi-ng-storybook-note>This story is to verify a bug where a nested track  with <code>horizontalAlignment=left</code> can't override the same prop of an ancestor track.<br>Here, the parent track is set to <code>right</code> and nested track to <code>left</code>. The nested track therefore must not align to right for the correct behaviour.</cvi-ng-storybook-note>
     <cvi-ng-track [gap]="gap" [horizontalAlignment]="horizontalAlignment" [verticalAlignment]="verticalAlignment" [flexDirection]="flexDirection" [flexIsMultiline]="flexIsMultiline" [layout]="layout">
       <div>Item 1</div>
       <cvi-ng-track [gap]="2" horizontalAlignment="left">

--- a/libs/ui/src/lib/track/track.component.ts
+++ b/libs/ui/src/lib/track/track.component.ts
@@ -27,6 +27,7 @@ export class TrackComponent {
   get hostCSSPropHorizontalAlignment(): string | null {
     return this.horizontalAlignment
       ? `
+      ${this.horizontalAlignment === 'normal' ? 'normal' : ''}
       ${this.horizontalAlignment === 'left' ? 'flex-start' : ''}
       ${this.horizontalAlignment === 'right' ? 'flex-end' : ''}
       ${this.horizontalAlignment === 'center' ? 'center' : ''}
@@ -34,8 +35,12 @@ export class TrackComponent {
     `
       : null;
   }
-  @Input() horizontalAlignment: 'left' | 'center' | 'right' | 'justify' =
-    'left';
+  @Input() horizontalAlignment:
+    | 'normal'
+    | 'left'
+    | 'center'
+    | 'right'
+    | 'justify' = 'normal';
 
   /** Equivalent of align-items in CSS */
   @HostBinding('style.--vertical-alignment')

--- a/libs/ui/src/lib/track/track.component.ts
+++ b/libs/ui/src/lib/track/track.component.ts
@@ -25,8 +25,9 @@ export class TrackComponent {
   /** Equivalent of justify-content in CSS */
   @HostBinding('style.--horizontal-alignment')
   get hostCSSPropHorizontalAlignment(): string | null {
-    return this.horizontalAlignment !== 'left'
+    return this.horizontalAlignment
       ? `
+      ${this.horizontalAlignment === 'left' ? 'flex-start' : ''}
       ${this.horizontalAlignment === 'right' ? 'flex-end' : ''}
       ${this.horizontalAlignment === 'center' ? 'center' : ''}
       ${this.horizontalAlignment === 'justify' ? 'space-between' : ''}

--- a/libs/ui/src/lib/track/track.html.stories.ts
+++ b/libs/ui/src/lib/track/track.html.stories.ts
@@ -27,7 +27,7 @@ export default {
     },
     horizontalAlignment: {
       name: 'Horizontal alignment',
-      options: ['flex-start', 'center', 'flex-end', 'space-between'],
+      options: ['normal', 'flex-start', 'center', 'flex-end', 'space-between'],
       control: { type: 'inline-radio' },
       if: { arg: 'flexDirection', eq: 'horizontal' },
     },
@@ -73,7 +73,7 @@ export default {
   args: {
     gap: 1,
     layout: 'flex',
-    horizontalAlignment: 'flex-start',
+    horizontalAlignment: 'normal',
     verticalAlignment: 'normal',
     flexDirection: 'horizontal',
     flexIsMultiline: 'nowrap',


### PR DESCRIPTION
To fix a nested track issue where it can't override the same prop of an ancestor track. Resolves #130.