### PR TITLE
fix(storybook): prevent Safari from losing a bottom border of the last header cell in the TableComponent (Angular) story due to invalid number of header cells

### DIFF
--- a/libs/ui/src/lib/table/table.component.stories.ts
+++ b/libs/ui/src/lib/table/table.component.stories.ts
@@ -126,6 +126,7 @@ const TemplateWithToolbar: Story<TableComponent> = (args: TableComponent) => {
   return {
     props: {
       ...args,
+      getStatusBadgeLabelBySeverity,
       form: form,
     },
     /* template */
@@ -155,7 +156,10 @@ const TemplateWithToolbar: Story<TableComponent> = (args: TableComponent) => {
 
       <ng-template #rows let-row>
         <td cvi-ng-body-cell>{{ row.event }}</td>
-        <td cvi-ng-body-cell>{{ row.status }}</td>
+        <td cvi-ng-body-cell>
+          <cvi-ng-status-badge [severity]="row.statusSeverity" [label]="getStatusBadgeLabelBySeverity(row.statusSeverity)"></cvi-ng-status-badge>
+        </td>
+        <td cvi-ng-body-cell>{{ row.email }}</td>
         <td cvi-ng-body-cell>{{ row.lastChanged }}</td>
         <td cvi-ng-body-cell>
           <cvi-ng-track [gap]="rowIconGap">

--- a/libs/ui/src/lib/table/table.component.stories.ts
+++ b/libs/ui/src/lib/table/table.component.stories.ts
@@ -75,6 +75,9 @@ const Template: Story<TableComponent> = (args: TableComponent) => ({
       <ng-container *ngFor="let headerLabel of headerLabels">
         <th cvi-ng-header-cell>{{ headerLabel }}</th>
       </ng-container>
+      <th cvi-ng-header-cell>
+        <cvi-ng-screenreader-text label="Icons"></cvi-ng-screenreader-text>
+      </th>
     </ng-template>
     <ng-template #rows let-row>
       <td cvi-ng-body-cell>{{ row.event }}</td>
@@ -145,6 +148,9 @@ const TemplateWithToolbar: Story<TableComponent> = (args: TableComponent) => {
         <ng-container *ngFor="let headerLabel of headerLabels">
           <th cvi-ng-header-cell>{{ headerLabel }}</th>
         </ng-container>
+        <th cvi-ng-header-cell>
+          <cvi-ng-screenreader-text label="Icons"></cvi-ng-screenreader-text>
+        </th>
       </ng-template>
 
       <ng-template #rows let-row>


### PR DESCRIPTION
In Safari 16.5 on MacOS and iOS, the bottom border of the last header cell of each TableComponent story is missing. This is because the number of header cells as set by the table configuration in the stories doesn't correspond to the number of body cells. 

Other browsers manage to mask this problem away. But since the generated markup is not valid, ideally we should get rid of this issue. 

The PR takes care of that.