### PR TITLE
feat: use cvi-ng-circle in steps EBS-880 STPA-280

### DIFF
--- a/apps/ui-e2e/src/component/step.component.cy.ts
+++ b/apps/ui-e2e/src/component/step.component.cy.ts
@@ -15,7 +15,7 @@ describe('StepComponent', () => {
           'is-current',
         ])
           .shouldHaveClasses('button', 'cvi-steps__list-item-button')
-          .shouldHaveClasses('div', 'cvi-steps__list-item-inner')
+          .shouldExist('cvi-ng-circle')
           .shouldHaveClasses('span', 'cvi-steps__list-item-title')
           .get('cvi-ng-icon')
           .shouldHaveClasses('svg', 'cvi-steps__list-item-arrow-icon');

--- a/libs/styles/src/lib/scss/components/_circle.scss
+++ b/libs/styles/src/lib/scss/components/_circle.scss
@@ -11,8 +11,8 @@
 
   border-radius: 51%;
   border: $circle-border-width solid var(--cvi-circle-border-color, var(--border-color));
-  color: var(--color);
-  fill: var(--color);
+  color: var(--cvi-circle-color, var(--color));
+  fill: var(--cvi-circle-color, var(--color));
   background-color: var(--background-color);
   line-height: 0;
   aspect-ratio: 1;

--- a/libs/styles/src/lib/scss/components/_steps.scss
+++ b/libs/styles/src/lib/scss/components/_steps.scss
@@ -226,18 +226,6 @@
           align-items: center;
         }
       }
-
-      #{$base}__list-item.is-current & {
-        @include cvi-breakpoint-up(sm) {
-          color: get-color(white);
-        }
-      }
-
-      #{$base}__list-item:not(.is-current) & {
-        @include cvi-breakpoint-up(sm) {
-          color: get-color(sapphire-blue-13);
-        }
-      }
     }
 
     #{$base}__list-item-title {
@@ -252,6 +240,11 @@
       @include cvi-breakpoint-up(sm) {
         #{$base}__list-item:not(.is-current) & {
           text-decoration: underline;
+          color: get-color(sapphire-blue-13);
+        }
+
+        #{$base}__list-item.is-current & {
+          color: get-color(white);
         }
       }
     }

--- a/libs/styles/src/lib/scss/components/_steps.scss
+++ b/libs/styles/src/lib/scss/components/_steps.scss
@@ -77,7 +77,6 @@
     }
 
     #{$base}__list {
-      counter-reset: numberedlist;
       list-style: none;
       gap: get-spacing('paldiski');
       @include cvi-breakpoint-down(sm) {
@@ -94,10 +93,7 @@
     }
 
     #{$base}__list-item {
-      counter-increment: numberedlist;
       @include cvi-breakpoint-down(sm) {
-        color: get-color(black-coral-15);
-        font-weight: get-font-weight(beta);
         border-top-left-radius: var(--cvi-radius-s);
         border-top-right-radius: var(--cvi-radius-s);
         background-color: get-color(white);
@@ -163,66 +159,6 @@
 
         &:focus-visible {
           outline: none;
-        }
-      }
-    }
-
-    #{$base}__list-item-inner {
-      @include cvi-breakpoint-down(sm) {
-        --number-background-color: var(--cvi-color-sapphire-blue-0);
-
-        display: flex;
-        width: 100%;
-        gap: get-spacing('haapsalu');
-        align-items: center;
-        color: get-color(sapphire-blue-10);
-
-        &::before {
-          flex-shrink: 0;
-          border-radius: 51%;
-          border: $number-border-width solid transparent;
-          content: counter(numberedlist);
-          width: $number-size--mobile;
-          background-image: linear-gradient(var(--number-background-color), var(--number-background-color)),
-            conic-gradient(
-              get-color(sapphire-blue-10) var(--progress),
-              get-color(black-coral-2) var(--progress)
-            );
-          background-origin: border-box;
-          background-clip: content-box, border-box;
-          aspect-ratio: 1;
-          display: flex;
-          justify-content: center;
-          align-items: center;
-          font-weight: get-font-weight(gamma);
-
-          #{$base}.is-any-step-selected & {
-            --number-background-color: var(--cvi-color-white);
-
-            color: get-color(black-coral-10);
-          }
-        }
-      }
-      @include cvi-breakpoint-up(sm) {
-        display: flex;
-        gap: get-spacing('paldiski');
-        width: 100%;
-        height: 100%;
-        align-items: center;
-
-        &::before {
-          content: counter(numberedlist);
-          border-radius: 51%;
-          border: $number-border-width solid currentColor;
-          color: currentColor;
-          font-size: get-font-size(80);
-          line-height: 0;
-          padding-inline: 8px;
-          width: $number-size--desktop;
-          aspect-ratio: 1;
-          display: flex;
-          justify-content: center;
-          align-items: center;
         }
       }
     }

--- a/libs/styles/src/lib/scss/components/_steps.scss
+++ b/libs/styles/src/lib/scss/components/_steps.scss
@@ -136,7 +136,6 @@
       font-size: get-font-size(100);
 
       @include cvi-breakpoint-down(sm) {
-        display: flex;
         width: 100%;
         padding-block: get-spacing('paldiski');
         #{$base}:not(.is-any-step-selected) & {
@@ -230,7 +229,7 @@
 
     #{$base}__list-item-title {
       @include cvi-breakpoint-down(sm) {
-        flex-grow: 1;
+        color: get-color(sapphire-blue-10);
         font-weight: get-font-weight(gamma);
         #{$base}.is-any-step-selected & {
           font-weight: get-font-weight(delta);
@@ -257,7 +256,7 @@
 
     #{$base}__list-item-arrow-icon {
       @include cvi-breakpoint-down(sm) {
-        fill: currentColor;
+        fill: get-color(sapphire-blue-10);
         height: 12px;
         #{$base}.is-any-step-selected & {
           display: none;

--- a/libs/styles/src/lib/scss/components/_steps.scss
+++ b/libs/styles/src/lib/scss/components/_steps.scss
@@ -227,6 +227,19 @@
       }
     }
 
+    #{$base}__list-item-circle-wrapper {
+      @include cvi-breakpoint-down(sm) {
+        &--desktop {
+          display: none;
+        }
+      }
+      @include cvi-breakpoint-up(sm) {
+        &--mobile {
+          display: none;
+        }
+      }
+    }
+
     #{$base}__list-item-title {
       @include cvi-breakpoint-down(sm) {
         color: get-color(sapphire-blue-10);

--- a/libs/ui/src/index.ts
+++ b/libs/ui/src/index.ts
@@ -15,6 +15,8 @@ export * from './lib/notification/notification';
 export * from './lib/notification/notification.component';
 export * from './lib/input/input.component';
 export * from './lib/steps/steps/steps.component';
+export * from './lib/steps/steps/to-step-circle-icon-name.pipe';
+export * from './lib/steps/steps/to-step-circle-severity.pipe';
 export * from './lib/steps/step/step.component';
 export * from './lib/steps/step-panel/step-panel.component';
 export * from './lib/radio-button/radio-button/radio-button.component';

--- a/libs/ui/src/lib/steps/step-panel/step-panel.component.ts
+++ b/libs/ui/src/lib/steps/step-panel/step-panel.component.ts
@@ -23,6 +23,15 @@ export class StepPanelComponent implements OnDestroy {
     return this._title;
   }
 
+  _status: 'success' | 'error' | null = null;
+  @Input()
+  set status(status: 'success' | 'error' | null) {
+    this._status = status;
+  }
+  get status(): 'success' | 'error' | null {
+    return this._status;
+  }
+
   /** @internal */
   public titleChangeSubject = new ReplaySubject<string>(1);
 

--- a/libs/ui/src/lib/steps/steps/steps.component.html
+++ b/libs/ui/src/lib/steps/steps/steps.component.html
@@ -9,11 +9,16 @@
           *ngFor="let stepTitle of stepTitles; let i = index"
           [ngClass]="{'is-past': this.currentStepIndex !== null && i <= currentStepIndex, 'is-current': i === currentStepIndex}"
           [dataAttribute]="'cvi-steps__list-item_' + i">
-        <button class="cvi-steps__list-item-button" [dataAttribute]="'cvi-steps__list-item-button_' + i" (click)="stepSelected(i)">
-          <div class="cvi-steps__list-item-inner">
+        <button class="cvi-steps__list-item-button" [dataAttribute]="'cvi-steps__list-item-button_' + i"
+                (click)="stepSelected(i)">
+          <cvi-ng-track [gap]="2" [verticalAlignment]="'center'">
+            <cvi-ng-circle [theme]="i === currentStepIndex ? 'light' : 'dark'">
+              {{ i + 1 }}
+            </cvi-ng-circle>
             <span class="cvi-steps__list-item-title">{{ stepTitle }}</span>
-            <cvi-ng-icon [name]="'arrow_a_right'" class="cvi-steps__list-item-arrow-icon-wrapper" [svgClass]="'cvi-steps__list-item-arrow-icon'"></cvi-ng-icon>
-          </div>
+            <cvi-ng-icon [name]="'arrow_a_right'" class="cvi-steps__list-item-arrow-icon-wrapper"
+                         [svgClass]="'cvi-steps__list-item-arrow-icon'"></cvi-ng-icon>
+          </cvi-ng-track>
         </button>
       </li>
     </ol>

--- a/libs/ui/src/lib/steps/steps/steps.component.html
+++ b/libs/ui/src/lib/steps/steps/steps.component.html
@@ -12,25 +12,28 @@
         <button class="cvi-steps__list-item-button" [dataAttribute]="'cvi-steps__list-item-button_' + i"
                 (click)="stepSelected(i)">
           <cvi-ng-track [layout]="'flex'" [horizontalAlignment]="'justify'" [verticalAlignment]="'center'">
-            <cvi-ng-track [gap]="2" [verticalAlignment]="'center'">
-              <div class="cvi-steps__list-item-circle-wrapper--desktop">
+            <div class="cvi-steps__list-item-circle-wrapper--desktop">
+              <cvi-ng-track [gap]="2" [verticalAlignment]="'center'">
                 <cvi-ng-circle
                   [theme]="i === currentStepIndex || this.stepStatuses[i] === 'success' || this.stepStatuses[i] === 'error'  ? 'light' : 'dark'"
                   [severity]="this.stepStatuses[i] | toStepCircleSeverity"
                   [iconName]="this.stepStatuses[i] | toStepCircleIconName">
                   {{ i + 1 }}
                 </cvi-ng-circle>
-              </div>
-              <div class="cvi-steps__list-item-circle-wrapper--mobile">
+                <span class="cvi-steps__list-item-title">{{ stepTitle }}</span>
+              </cvi-ng-track>
+            </div>
+            <div class="cvi-steps__list-item-circle-wrapper--mobile">
+              <cvi-ng-track [gap]="4" [verticalAlignment]="'center'">
                 <cvi-ng-circle
                   size="m"
                   style="--cvi-circle-border-color: var(--cvi-color-sapphire-blue-10); --cvi-circle-color: var(--cvi-color-sapphire-blue-10);"
                   [progressPercentage]="anyStepSelected ? currentProgressCSSVar : undefined">
                   {{ i + 1 }}
                 </cvi-ng-circle>
-              </div>
-              <span class="cvi-steps__list-item-title">{{ stepTitle }}</span>
-            </cvi-ng-track>
+                <span class="cvi-steps__list-item-title">{{ stepTitle }}</span>
+              </cvi-ng-track>
+            </div>
             <cvi-ng-track [gap]="4">
               <cvi-ng-icon [name]="'arrow_a_right'" class="cvi-steps__list-item-arrow-icon-wrapper"
                            [svgClass]="'cvi-steps__list-item-arrow-icon'"></cvi-ng-icon>

--- a/libs/ui/src/lib/steps/steps/steps.component.html
+++ b/libs/ui/src/lib/steps/steps/steps.component.html
@@ -11,13 +11,17 @@
           [dataAttribute]="'cvi-steps__list-item_' + i">
         <button class="cvi-steps__list-item-button" [dataAttribute]="'cvi-steps__list-item-button_' + i"
                 (click)="stepSelected(i)">
-          <cvi-ng-track [gap]="2" [verticalAlignment]="'center'">
-            <cvi-ng-circle [theme]="i === currentStepIndex ? 'light' : 'dark'">
-              {{ i + 1 }}
-            </cvi-ng-circle>
-            <span class="cvi-steps__list-item-title">{{ stepTitle }}</span>
-            <cvi-ng-icon [name]="'arrow_a_right'" class="cvi-steps__list-item-arrow-icon-wrapper"
-                         [svgClass]="'cvi-steps__list-item-arrow-icon'"></cvi-ng-icon>
+          <cvi-ng-track [layout]="'flex'" [horizontalAlignment]="'justify'" [verticalAlignment]="'center'">
+            <cvi-ng-track [gap]="2" [verticalAlignment]="'center'">
+              <cvi-ng-circle [theme]="i === currentStepIndex ? 'light' : 'dark'">
+                {{ i + 1 }}
+              </cvi-ng-circle>
+              <span class="cvi-steps__list-item-title">{{ stepTitle }}</span>
+            </cvi-ng-track>
+            <cvi-ng-track [gap]="4">
+              <cvi-ng-icon [name]="'arrow_a_right'" class="cvi-steps__list-item-arrow-icon-wrapper"
+                           [svgClass]="'cvi-steps__list-item-arrow-icon'"></cvi-ng-icon>
+            </cvi-ng-track>
           </cvi-ng-track>
         </button>
       </li>

--- a/libs/ui/src/lib/steps/steps/steps.component.html
+++ b/libs/ui/src/lib/steps/steps/steps.component.html
@@ -15,7 +15,8 @@
             <cvi-ng-track [gap]="2" [verticalAlignment]="'center'">
               <div class="cvi-steps__list-item-circle-wrapper--desktop">
                 <cvi-ng-circle [theme]="i === currentStepIndex ? 'light' : 'dark'"
-                               [severity]="(this.stepStatuses[i]) | toStepCircleSeverity">
+                               [severity]="(this.stepStatuses[i]) | toStepCircleSeverity"
+                               [iconName]="(this.stepStatuses[i]) | toStepCircleIconName">
                   {{ i + 1 }}
                 </cvi-ng-circle>
               </div>

--- a/libs/ui/src/lib/steps/steps/steps.component.html
+++ b/libs/ui/src/lib/steps/steps/steps.component.html
@@ -14,7 +14,8 @@
           <cvi-ng-track [layout]="'flex'" [horizontalAlignment]="'justify'" [verticalAlignment]="'center'">
             <cvi-ng-track [gap]="2" [verticalAlignment]="'center'">
               <div class="cvi-steps__list-item-circle-wrapper--desktop">
-                <cvi-ng-circle [theme]="i === currentStepIndex ? 'light' : 'dark'">
+                <cvi-ng-circle [theme]="i === currentStepIndex ? 'light' : 'dark'"
+                               [severity]="(this.stepStatuses[i]) | toStepCircleSeverity">
                   {{ i + 1 }}
                 </cvi-ng-circle>
               </div>

--- a/libs/ui/src/lib/steps/steps/steps.component.html
+++ b/libs/ui/src/lib/steps/steps/steps.component.html
@@ -4,7 +4,7 @@
     <ng-content select="[cvi-steps=after-title]"></ng-content>
   </div>
   <div class="cvi-steps__inner" dataAttribute="steps_container">
-    <ol class="cvi-steps__list" [style.--progress]="anyStepSelected ? currentProgressCSSVar + '%' : '100%'">
+    <ol class="cvi-steps__list">
       <li class="cvi-steps__list-item"
           *ngFor="let stepTitle of stepTitles; let i = index"
           [ngClass]="{'is-past': this.currentStepIndex !== null && i <= currentStepIndex, 'is-current': i === currentStepIndex}"
@@ -13,9 +13,18 @@
                 (click)="stepSelected(i)">
           <cvi-ng-track [layout]="'flex'" [horizontalAlignment]="'justify'" [verticalAlignment]="'center'">
             <cvi-ng-track [gap]="2" [verticalAlignment]="'center'">
-              <cvi-ng-circle [theme]="i === currentStepIndex ? 'light' : 'dark'">
-                {{ i + 1 }}
-              </cvi-ng-circle>
+              <div class="cvi-steps__list-item-circle-wrapper--desktop">
+                <cvi-ng-circle [theme]="i === currentStepIndex ? 'light' : 'dark'">
+                  {{ i + 1 }}
+                </cvi-ng-circle>
+              </div>
+              <div class="cvi-steps__list-item-circle-wrapper--mobile">
+                <cvi-ng-circle
+                  [theme]="'dark'"
+                  [progressPercentage]="anyStepSelected ? currentProgressCSSVar : undefined">
+                  {{ i + 1 }}
+                </cvi-ng-circle>
+              </div>
               <span class="cvi-steps__list-item-title">{{ stepTitle }}</span>
             </cvi-ng-track>
             <cvi-ng-track [gap]="4">

--- a/libs/ui/src/lib/steps/steps/steps.component.html
+++ b/libs/ui/src/lib/steps/steps/steps.component.html
@@ -20,7 +20,8 @@
               </div>
               <div class="cvi-steps__list-item-circle-wrapper--mobile">
                 <cvi-ng-circle
-                  [theme]="'dark'"
+                  size="m"
+                  style="--cvi-circle-border-color: var(--cvi-color-sapphire-blue-10); --cvi-circle-color: var(--cvi-color-sapphire-blue-10);"
                   [progressPercentage]="anyStepSelected ? currentProgressCSSVar : undefined">
                   {{ i + 1 }}
                 </cvi-ng-circle>

--- a/libs/ui/src/lib/steps/steps/steps.component.html
+++ b/libs/ui/src/lib/steps/steps/steps.component.html
@@ -14,9 +14,10 @@
           <cvi-ng-track [layout]="'flex'" [horizontalAlignment]="'justify'" [verticalAlignment]="'center'">
             <cvi-ng-track [gap]="2" [verticalAlignment]="'center'">
               <div class="cvi-steps__list-item-circle-wrapper--desktop">
-                <cvi-ng-circle [theme]="i === currentStepIndex ? 'light' : 'dark'"
-                               [severity]="(this.stepStatuses[i]) | toStepCircleSeverity"
-                               [iconName]="(this.stepStatuses[i]) | toStepCircleIconName">
+                <cvi-ng-circle
+                  [theme]="i === currentStepIndex || this.stepStatuses[i] === 'success' || this.stepStatuses[i] === 'error'  ? 'light' : 'dark'"
+                  [severity]="this.stepStatuses[i] | toStepCircleSeverity"
+                  [iconName]="this.stepStatuses[i] | toStepCircleIconName">
                   {{ i + 1 }}
                 </cvi-ng-circle>
               </div>

--- a/libs/ui/src/lib/steps/steps/steps.component.stories.ts
+++ b/libs/ui/src/lib/steps/steps/steps.component.stories.ts
@@ -226,3 +226,40 @@ WithHTMLSections.parameters = {
     disabledRules: ['button-name'],
   },
 };
+
+const TemplateWithStepStatus: Story = (args) => ({
+  component: StepsComponent,
+  props: {
+    ...args,
+  },
+  /* template */
+  template: `
+    <cvi-ng-steps [title]="title" [currentStepIndex]="currentStepIndex">
+      <cvi-ng-step>
+        <cvi-ng-step-panel title="First" [status]="null">
+          <span>Status is set to 'null'.</span>
+        </cvi-ng-step-panel>
+      </cvi-ng-step>
+      <cvi-ng-step>
+        <cvi-ng-step-panel title="Second" [status]="'success'">
+          <span>Success status!</span>
+        </cvi-ng-step-panel>
+      </cvi-ng-step>
+      <cvi-ng-step>
+        <cvi-ng-step-panel title="Third">
+          <span>Status is not set.</span>
+        </cvi-ng-step-panel>
+      </cvi-ng-step>
+      <cvi-ng-step>
+        <cvi-ng-step-panel title="Fourth" [status]="'error'">
+          <span>Error status!</span>
+        </cvi-ng-step-panel>
+      </cvi-ng-step>
+    </cvi-ng-steps>
+  `,
+});
+
+export const WithStepStatuses = TemplateWithStepStatus.bind({});
+WithStepStatuses.args = {
+  currentStepIndex: 0,
+};

--- a/libs/ui/src/lib/steps/steps/steps.component.ts
+++ b/libs/ui/src/lib/steps/steps/steps.component.ts
@@ -50,6 +50,7 @@ export class StepsComponent
 
   @Output() stepChange = new EventEmitter<number>();
 
+  stepStatuses!: ('success' | 'error' | null)[];
   stepTitles!: string[];
   @Input() currentProgressCSSVar = 0;
   @Input() anyStepSelected = false;
@@ -95,7 +96,7 @@ export class StepsComponent
   }
 
   ngAfterContentInit(): void {
-    this.updateTitles(this._stepPanels.toArray());
+    this.updateStepsData(this._stepPanels.toArray());
     if (this.currentStepIndex !== null) {
       this.anyStepSelected = true;
       this.setProgress(this.currentStepIndex);
@@ -109,7 +110,7 @@ export class StepsComponent
       this.cdRef.markForCheck();
     });
     this._stepPanels.changes.subscribe((stepPanels: StepPanelComponent[]) => {
-      this.updateTitles(stepPanels);
+      this.updateStepsData(stepPanels);
       this.cdRef.markForCheck();
     });
   }
@@ -127,9 +128,12 @@ export class StepsComponent
     }
   }
 
-  updateTitles(stepPanels: StepPanelComponent[]) {
+  updateStepsData(stepPanels: StepPanelComponent[]) {
     this.stepTitles = stepPanels.map(
       (stepPanel: StepPanelComponent) => stepPanel.title
+    );
+    this.stepStatuses = stepPanels.map(
+      (stepPanel: StepPanelComponent) => stepPanel.status
     );
   }
 

--- a/libs/ui/src/lib/steps/steps/steps.html.stories.ts
+++ b/libs/ui/src/lib/steps/steps/steps.html.stories.ts
@@ -13,100 +13,228 @@ const Template: Story = (args) => ({
   props: args,
   /* template */
   template: `
-    <div class="cvi-steps is-any-step-selected">
+    <div class="cvi-steps is-any-step-selected" style="--current-step: '2';">
       <h1 class="cvi-steps__title">Abiellumine</h1>
       <div class="cvi-steps__inner-wrapper">
-        <div class="cvi-steps__intro">
-          <p>You can now add custom content before steps</p>
-        </div>
+        <div class="cvi-steps__intro"><p>You can now add custom content before steps</p></div>
         <div class="cvi-steps__inner">
-          <ol class="cvi-steps__list" style="--progress:50%;">
+          <ol class="cvi-steps__list">
             <li class="cvi-steps__list-item is-past">
               <button class="cvi-steps__list-item-button">
-                <div class="cvi-steps__list-item-inner">
-                  <span class="cvi-steps__list-item-title">Abiellumine</span>
-                  <span class="cvi-steps__list-item-arrow-icon-wrapper">
-                    <svg viewBox="0 0 8 12" xmlns="http://www.w3.org/2000/svg" class="cvi-steps__list-item-arrow-icon" height="24px">
-                      <path d="m7.485 6.634-5.101 5.101a.896.896 0 0 1-1.272 0l-.848-.847a.897.897 0 0 1 0-1.272L3.881 6 .264 2.384a.897.897 0 0 1 0-1.272l.848-.848a.897.897 0 0 1 1.272 0l5.101 5.102a.892.892 0 0 1 0 1.268Z"></path>
-                    </svg>
-                  </span>
+                <div
+                  class="cvi-track cvi-track--direction-horizontal cvi-track--layout-flex"
+                  style="--gap: 0; --horizontal-alignment: space-between; --vertical-alignment: center;">
+                  <div class="cvi-steps__list-item-circle-wrapper--desktop">
+                    <div
+                      class="cvi-track cvi-track--direction-horizontal cvi-track--layout-flex"
+                      style="--gap: 2; --horizontal-alignment: normal; --vertical-alignment: center;">
+                      <span
+                        class="cvi-circle cvi-circle--severity-none cvi-circle--size-s"
+                        style="--border-color: var(--cvi-color-sapphire-blue-13); --color: var(--cvi-color-sapphire-blue-13); --background-color: transparent; --progress-background-color: var(--cvi-color-white);">
+                        1
+                      </span>
+                      <span class="cvi-steps__list-item-title">Abiellumine</span>
+                    </div>
+                  </div>
+                  <div class="cvi-steps__list-item-circle-wrapper--mobile">
+                    <div
+                      class="cvi-track cvi-track--direction-horizontal cvi-track--layout-flex"
+                      style="--gap: 4; --horizontal-alignment: normal; --vertical-alignment: center;">
+                      <span
+                        style="--cvi-circle-border-color: var(--cvi-color-sapphire-blue-10); --cvi-circle-color: var(--cvi-color-sapphire-blue-10); --border-color: var(--cvi-color-white); --color: var(--cvi-color-white); --background-color: transparent; --progress: 20%; --progress-background-color: var(--cvi-color-white);"
+                        class="cvi-circle cvi-circle--severity-none cvi-circle--size-m cvi-circle--with-progress">
+                        1
+                      </span>
+                      <span class="cvi-steps__list-item-title">Abiellumine</span>
+                    </div>
+                  </div>
+                  <div
+                    class="cvi-track cvi-track--direction-horizontal cvi-track--layout-flex"
+                    style="--gap: 4; --horizontal-alignment: normal;">
+                    <span class="cvi-steps__list-item-arrow-icon-wrapper">
+                      <svg viewBox="0 0 8 12" xmlns="http://www.w3.org/2000/svg" height="24px"
+                           class="cvi-steps__list-item-arrow-icon">
+                        <path
+                          d="m7.485 6.634-5.101 5.101a.896.896 0 0 1-1.272 0l-.848-.847a.897.897 0 0 1 0-1.272L3.881 6 .264 2.384a.897.897 0 0 1 0-1.272l.848-.848a.897.897 0 0 1 1.272 0l5.101 5.102a.892.892 0 0 1 0 1.268Z"></path>
+                      </svg>
+                    </span>
+                  </div>
                 </div>
               </button>
             </li>
             <li class="cvi-steps__list-item is-past is-current">
               <button class="cvi-steps__list-item-button">
-                <div class="cvi-steps__list-item-inner">
-                  <span class="cvi-steps__list-item-title">Second</span>
-                  <span class="cvi-steps__list-item-arrow-icon-wrapper">
-                    <svg viewBox="0 0 8 12" xmlns="http://www.w3.org/2000/svg" class="cvi-steps__list-item-arrow-icon" height="24px">
-                      <path d="m7.485 6.634-5.101 5.101a.896.896 0 0 1-1.272 0l-.848-.847a.897.897 0 0 1 0-1.272L3.881 6 .264 2.384a.897.897 0 0 1 0-1.272l.848-.848a.897.897 0 0 1 1.272 0l5.101 5.102a.892.892 0 0 1 0 1.268Z"></path>
-                    </svg>
-                  </span>
+                <div
+                  class="cvi-track cvi-track--direction-horizontal cvi-track--layout-flex"
+                  style="--gap: 0; --horizontal-alignment: space-between; --vertical-alignment: center;">
+                  <div class="cvi-steps__list-item-circle-wrapper--desktop">
+                    <div
+                      class="cvi-track cvi-track--direction-horizontal cvi-track--layout-flex"
+                      style="--gap: 2; --horizontal-alignment: normal; --vertical-alignment: center;">
+                      <span
+                        class="cvi-circle cvi-circle--severity-none cvi-circle--size-s"
+                        style="--border-color: var(--cvi-color-white); --color: var(--cvi-color-white); --background-color: transparent; --progress-background-color: var(--cvi-color-white);">
+                        2
+                      </span>
+                      <span class="cvi-steps__list-item-title">Second</span>
+                    </div>
+                  </div>
+                  <div class="cvi-steps__list-item-circle-wrapper--mobile">
+                    <div
+                      class="cvi-track cvi-track--direction-horizontal cvi-track--layout-flex"
+                      style="--gap: 4; --horizontal-alignment: normal; --vertical-alignment: center;">
+                      <span
+                        style="--cvi-circle-border-color: var(--cvi-color-sapphire-blue-10); --cvi-circle-color: var(--cvi-color-sapphire-blue-10); --border-color: var(--cvi-color-white); --color: var(--cvi-color-white); --background-color: transparent; --progress: 50%; --progress-background-color: var(--cvi-color-white);"
+                        class="cvi-circle cvi-circle--severity-none cvi-circle--size-m cvi-circle--with-progress">
+                        2
+                      </span>
+                      <span class="cvi-steps__list-item-title">Second</span>
+                    </div>
+                  </div>
+                  <div
+                    class="cvi-track cvi-track--direction-horizontal cvi-track--layout-flex"
+                    style="--gap: 4; --horizontal-alignment: normal;">
+                    <span class="cvi-steps__list-item-arrow-icon-wrapper">
+                      <svg viewBox="0 0 8 12" xmlns="http://www.w3.org/2000/svg" height="24px"
+                           class="cvi-steps__list-item-arrow-icon">
+                        <path
+                          d="m7.485 6.634-5.101 5.101a.896.896 0 0 1-1.272 0l-.848-.847a.897.897 0 0 1 0-1.272L3.881 6 .264 2.384a.897.897 0 0 1 0-1.272l.848-.848a.897.897 0 0 1 1.272 0l5.101 5.102a.892.892 0 0 1 0 1.268Z"></path>
+                      </svg>
+                    </span>
+                  </div>
                 </div>
               </button>
             </li>
             <li class="cvi-steps__list-item">
               <button class="cvi-steps__list-item-button">
-                <div class="cvi-steps__list-item-inner">
-                  <span class="cvi-steps__list-item-title">Third</span>
-                  <span class="cvi-steps__list-item-arrow-icon-wrapper">
-                    <svg viewBox="0 0 8 12" xmlns="http://www.w3.org/2000/svg" class="cvi-steps__list-item-arrow-icon" height="24px">
-                      <path d="m7.485 6.634-5.101 5.101a.896.896 0 0 1-1.272 0l-.848-.847a.897.897 0 0 1 0-1.272L3.881 6 .264 2.384a.897.897 0 0 1 0-1.272l.848-.848a.897.897 0 0 1 1.272 0l5.101 5.102a.892.892 0 0 1 0 1.268Z"></path>
-                    </svg>
-                  </span>
+                <div
+                  class="cvi-track cvi-track--direction-horizontal cvi-track--layout-flex"
+                  style="--gap: 0; --horizontal-alignment: space-between; --vertical-alignment: center;">
+                  <div class="cvi-steps__list-item-circle-wrapper--desktop">
+                    <div
+                      class="cvi-track cvi-track--direction-horizontal cvi-track--layout-flex"
+                      style="--gap: 2; --horizontal-alignment: normal; --vertical-alignment: center;">
+                      <span
+                        class="cvi-circle cvi-circle--severity-none cvi-circle--size-s"
+                        style="--border-color: var(--cvi-color-sapphire-blue-13); --color: var(--cvi-color-sapphire-blue-13); --background-color: transparent; --progress-background-color: var(--cvi-color-white);">
+                        3
+                      </span>
+                      <span class="cvi-steps__list-item-title">Third</span>
+                    </div>
+                  </div>
+                  <div class="cvi-steps__list-item-circle-wrapper--mobile">
+                    <div
+                      class="cvi-track cvi-track--direction-horizontal cvi-track--layout-flex"
+                      style="--gap: 4; --horizontal-alignment: normal; --vertical-alignment: center;">
+                      <span
+                        style="--cvi-circle-border-color: var(--cvi-color-sapphire-blue-10); --cvi-circle-color: var(--cvi-color-sapphire-blue-10); --border-color: var(--cvi-color-white); --color: var(--cvi-color-white); --background-color: transparent; --progress: 75%; --progress-background-color: var(--cvi-color-white);"
+                        class="cvi-circle cvi-circle--severity-none cvi-circle--size-m cvi-circle--with-progress">
+                        3
+                      </span>
+                      <span class="cvi-steps__list-item-title">Third</span>
+                    </div>
+                  </div>
+                  <div
+                    class="cvi-track cvi-track--direction-horizontal cvi-track--layout-flex"
+                    style="--gap: 4; --horizontal-alignment: normal;">
+                    <span class="cvi-steps__list-item-arrow-icon-wrapper">
+                      <svg viewBox="0 0 8 12" xmlns="http://www.w3.org/2000/svg" height="24px"
+                           class="cvi-steps__list-item-arrow-icon">
+                        <path
+                          d="m7.485 6.634-5.101 5.101a.896.896 0 0 1-1.272 0l-.848-.847a.897.897 0 0 1 0-1.272L3.881 6 .264 2.384a.897.897 0 0 1 0-1.272l.848-.848a.897.897 0 0 1 1.272 0l5.101 5.102a.892.892 0 0 1 0 1.268Z"></path>
+                      </svg>
+                    </span>
+                  </div>
                 </div>
               </button>
             </li>
             <li class="cvi-steps__list-item">
               <button class="cvi-steps__list-item-button">
-                <div class="cvi-steps__list-item-inner">
-                  <span class="cvi-steps__list-item-title">Fourth</span>
-                  <span class="cvi-steps__list-item-arrow-icon-wrapper">
-                    <svg viewBox="0 0 8 12" xmlns="http://www.w3.org/2000/svg" class="cvi-steps__list-item-arrow-icon" height="24px">
-                      <path d="m7.485 6.634-5.101 5.101a.896.896 0 0 1-1.272 0l-.848-.847a.897.897 0 0 1 0-1.272L3.881 6 .264 2.384a.897.897 0 0 1 0-1.272l.848-.848a.897.897 0 0 1 1.272 0l5.101 5.102a.892.892 0 0 1 0 1.268Z"
-                     ></path>
-                    </svg>
-                  </span>
+                <div
+                  class="cvi-track cvi-track--direction-horizontal cvi-track--layout-flex"
+                  style="--gap: 0; --horizontal-alignment: space-between; --vertical-alignment: center;">
+                  <div class="cvi-steps__list-item-circle-wrapper--desktop">
+                    <div
+                      class="cvi-track cvi-track--direction-horizontal cvi-track--layout-flex"
+                      style="--gap: 2; --horizontal-alignment: normal; --vertical-alignment: center;">
+                      <span
+                        class="cvi-circle cvi-circle--severity-none cvi-circle--size-s"
+                        style="--border-color: var(--cvi-color-sapphire-blue-13); --color: var(--cvi-color-sapphire-blue-13); --background-color: transparent; --progress-background-color: var(--cvi-color-white);">
+                        4
+                      </span>
+                      <span class="cvi-steps__list-item-title">Fourth</span>
+                    </div>
+                  </div>
+                  <div class="cvi-steps__list-item-circle-wrapper--mobile">
+                    <div
+                      class="cvi-track cvi-track--direction-horizontal cvi-track--layout-flex"
+                      style="--gap: 4; --horizontal-alignment: normal; --vertical-alignment: center;">
+                      <span
+                        style="--cvi-circle-border-color: var(--cvi-color-sapphire-blue-10); --cvi-circle-color: var(--cvi-color-sapphire-blue-10); --border-color: var(--cvi-color-white); --color: var(--cvi-color-white); --background-color: transparent; --progress: 100%; --progress-background-color: var(--cvi-color-white);"
+                        class="cvi-circle cvi-circle--severity-none cvi-circle--size-m cvi-circle--with-progress">
+                        4
+                      </span>
+                      <span class="cvi-steps__list-item-title">Fourth</span>
+                    </div>
+                  </div>
+                  <div
+                    class="cvi-track cvi-track--direction-horizontal cvi-track--layout-flex"
+                    style="--gap: 4; --horizontal-alignment: normal;">
+                    <span class="cvi-steps__list-item-arrow-icon-wrapper">
+                      <svg viewBox="0 0 8 12" xmlns="http://www.w3.org/2000/svg" height="24px"
+                           class="cvi-steps__list-item-arrow-icon">
+                        <path
+                          d="m7.485 6.634-5.101 5.101a.896.896 0 0 1-1.272 0l-.848-.847a.897.897 0 0 1 0-1.272L3.881 6 .264 2.384a.897.897 0 0 1 0-1.272l.848-.848a.897.897 0 0 1 1.272 0l5.101 5.102a.892.892 0 0 1 0 1.268Z"></path>
+                      </svg>
+                    </span>
+                  </div>
                 </div>
               </button>
             </li>
           </ol>
-          <div class="cvi-steps__step">
-          </div>
+          <div class="cvi-steps__step"></div>
           <div class="cvi-steps__step">
             <div class="cvi-steps__content-panel">
-              <h2 class="cvi-steps__content-panel-title">Abiellumine</h2>
-              <p>Fetal stemcells, aren't those controversial? In your time, yes, but nowadays shut up! Besides, these are adult stemcells, harvested from perfectly healthy adults whom I killed for their stemcells. Bender?! You stole the atom.</p>
+              <h2 class="cvi-steps__content-panel-title">Second</h2>
+              <p>
+                Fetal stemcells, aren't those controversial? In your time, yes, but nowadays shut up! Besides, these are
+                adult stemcells,
+                harvested from perfectly healthy adults whom I killed for their stemcells. Bender?! You stole the atom.
+              </p>
             </div>
           </div>
-          <div class="cvi-steps__step">
-          </div>
-          <div class="cvi-steps__step">
-          </div>
+          <div class="cvi-steps__step"></div>
+          <div class="cvi-steps__step"></div>
           <div class="cvi-steps__directional-buttons">
-            <button class="cvi-steps__directional-button cvi-steps__directional-button--direction-prev" title="Abiellumine">
+            <button title="Abiellumine" class="cvi-steps__directional-button cvi-steps__directional-button--direction-prev">
               <span>
-                <svg viewBox="0 0 8 12" xmlns="http://www.w3.org/2000/svg" class="cvi-steps__directional-button-icon" height="24px">
-                  <path d="M.515 5.366 5.616.264a.897.897 0 0 1 1.272 0l.848.848a.897.897 0 0 1 0 1.272L4.119 6l3.617 3.616a.897.897 0 0 1 0 1.272l-.848.848a.896.896 0 0 1-1.272 0L.515 6.633a.892.892 0 0 1 0-1.268Z"></path>
+                <svg viewBox="0 0 8 12" xmlns="http://www.w3.org/2000/svg" height="24px"
+                     class="cvi-steps__directional-button-icon">
+                  <path
+                    d="M.515 5.366 5.616.264a.897.897 0 0 1 1.272 0l.848.848a.897.897 0 0 1 0 1.272L4.119 6l3.617 3.616a.897.897 0 0 1 0 1.272l-.848.848a.896.896 0 0 1-1.272 0L.515 6.633a.892.892 0 0 1 0-1.268Z"></path>
                 </svg>
               </span>
               <span class="cvi-steps__directional-button-label">Abiellumine</span>
             </button>
-            <button class="cvi-steps__directional-button cvi-steps__directional-button--direction-next" title="Second">
-              <span class="cvi-steps__directional-button-label">Second</span>
+            <button title="Third" class="cvi-steps__directional-button cvi-steps__directional-button--direction-next">
+              <span class="cvi-steps__directional-button-label">Third</span>
               <span>
-                <svg viewBox="0 0 8 12" xmlns="http://www.w3.org/2000/svg" class="cvi-steps__directional-button-icon" height="24px">
-                  <path d="m7.485 6.634-5.101 5.101a.896.896 0 0 1-1.272 0l-.848-.847a.897.897 0 0 1 0-1.272L3.881 6 .264 2.384a.897.897 0 0 1 0-1.272l.848-.848a.897.897 0 0 1 1.272 0l5.101 5.102a.892.892 0 0 1 0 1.268Z"></path>
+                <svg viewBox="0 0 8 12" xmlns="http://www.w3.org/2000/svg" height="24px"
+                     class="cvi-steps__directional-button-icon">
+                  <path
+                    d="m7.485 6.634-5.101 5.101a.896.896 0 0 1-1.272 0l-.848-.847a.897.897 0 0 1 0-1.272L3.881 6 .264 2.384a.897.897 0 0 1 0-1.272l.848-.848a.897.897 0 0 1 1.272 0l5.101 5.102a.892.892 0 0 1 0 1.268Z"></path>
                 </svg>
               </span>
             </button>
           </div>
         </div>
       </div>
-      <svg width="0" height="0" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" style="visibility: hidden; position: absolute;">
+      <svg width="0" height="0" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"
+           style="visibility: hidden; position: absolute;">
         <filter id="round">
           <feGaussianBlur in="SourceGraphic" stdDeviation="2" result="blur"></feGaussianBlur>
-          <feColorMatrix in="blur" mode="matrix" values="1 0 0 0 0 0 1 0 0 0 0 0 1 0 0 0 0 0 19 -9" result="goo"></feColorMatrix>
+          <feColorMatrix in="blur" mode="matrix" values="1 0 0 0 0 0 1 0 0 0 0 0 1 0 0 0 0 0 19 -9"
+                         result="goo"></feColorMatrix>
           <feComposite in="SourceGraphic" in2="goo" operator="atop"></feComposite>
         </filter>
       </svg>

--- a/libs/ui/src/lib/steps/steps/to-step-circle-icon-name.pipe.ts
+++ b/libs/ui/src/lib/steps/steps/to-step-circle-icon-name.pipe.ts
@@ -1,0 +1,18 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { CviIconName } from '@egov/cvi-icons';
+
+@Pipe({
+  name: 'toStepCircleIconName',
+})
+export class ToStepCircleIconNamePipe implements PipeTransform {
+  transform(value: 'error' | 'success' | null): CviIconName | undefined {
+    switch (value) {
+      case 'success':
+        return 'check';
+      case 'error':
+        return 'close';
+      default:
+        return undefined;
+    }
+  }
+}

--- a/libs/ui/src/lib/steps/steps/to-step-circle-severity.pipe.ts
+++ b/libs/ui/src/lib/steps/steps/to-step-circle-severity.pipe.ts
@@ -1,0 +1,18 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { CircleSeverity } from '../../circle/circle';
+
+@Pipe({
+  name: 'toStepCircleSeverity',
+})
+export class ToStepCircleSeverityPipe implements PipeTransform {
+  transform(value: 'error' | 'success' | null): CircleSeverity {
+    switch (value) {
+      case 'success':
+        return 'success';
+      case 'error':
+        return 'error';
+      default:
+        return 'none';
+    }
+  }
+}

--- a/libs/ui/src/lib/ui.module.ts
+++ b/libs/ui/src/lib/ui.module.ts
@@ -1,6 +1,7 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { CircleComponent } from './circle/circle.component';
+import { ToStepCircleSeverityPipe } from './steps/steps/to-step-circle-severity.pipe';
 
 import { TrackComponent } from './track/track.component';
 import { ContentContainerComponent } from './content-container/content-container.component';
@@ -171,6 +172,7 @@ const pipes = [
   NotificationSeverityToHeaderIconPipe,
   TimedNoticeSeverityToIconPipe,
   FormMessageSeverityToHeaderIconPipe,
+  ToStepCircleSeverityPipe,
 ];
 
 const directives = [DataAttributeDirective];

--- a/libs/ui/src/lib/ui.module.ts
+++ b/libs/ui/src/lib/ui.module.ts
@@ -1,6 +1,7 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { CircleComponent } from './circle/circle.component';
+import { ToStepCircleIconNamePipe } from './steps/steps/to-step-circle-icon-name.pipe';
 import { ToStepCircleSeverityPipe } from './steps/steps/to-step-circle-severity.pipe';
 
 import { TrackComponent } from './track/track.component';
@@ -173,6 +174,7 @@ const pipes = [
   TimedNoticeSeverityToIconPipe,
   FormMessageSeverityToHeaderIconPipe,
   ToStepCircleSeverityPipe,
+  ToStepCircleIconNamePipe,
 ];
 
 const directives = [DataAttributeDirective];


### PR DESCRIPTION
Refactored the `cvi-ng-steps` component to use `cvi-ng-circle` instead of CSS content counter.
Added a _status_ input to `cvi-step-panel` to allow styling the step circle by the step status (success, error).