### PR TITLE
docs(storybook): try to reproduce a bug in cvi-ng-responsive-table with translations

### DIFF
--- a/libs/storybook/src/assets/i18n/en.json
+++ b/libs/storybook/src/assets/i18n/en.json
@@ -4,6 +4,9 @@
       "title": "Abiellumine (English translation)",
       "step1": "This is an English translation provided via @ngx-translate",
       "step2": "This is another English thing provided via @ngx-translate"
+    },
+    "tableResponsive": {
+      "headerLabels": ["Monday", "Tuesday"]
     }
   }
 }

--- a/libs/storybook/src/assets/i18n/et.json
+++ b/libs/storybook/src/assets/i18n/et.json
@@ -4,6 +4,9 @@
       "title": "Abiellumine (Eesti keeles)",
       "step1": "Esimene samm",
       "step2": "Teine samm"
+    },
+    "tableResponsive": {
+      "headerLabels": ["Esmaspäev", "Teisipäev"]
     }
   }
 }

--- a/libs/ui/src/lib/table-responsive/table-responsive.component.stories.ts
+++ b/libs/ui/src/lib/table-responsive/table-responsive.component.stories.ts
@@ -162,3 +162,37 @@ WithCustomHeaderAndBodyMobile.parameters = {
     defaultViewport: 'iphone12mini',
   },
 };
+
+
+const TemplateWithTranslations: Story<TableResponsiveComponent> = (
+  args: TableResponsiveComponent
+) => ({
+  props: {
+    ...args,
+    data: [
+      {
+        who: "Monkey",
+        what: "see-do"
+      },
+      {
+        "who": "Bear",
+        "what": "drink-drank-drunk"
+      }
+    ]
+  },
+  /* template */
+  template: `
+    <cvi-ng-table-responsive [data]="data" [headerLabels]="'common.tableResponsive.headerLabels' | translate"></cvi-ng-table-responsive>
+  `,
+});
+
+export const WithTranslations = TemplateWithTranslations.bind({});
+WithTranslations.parameters = {
+  layout: 'fullscreen',
+  backgrounds: {
+    default: 'light',
+  },
+  viewport: {
+    defaultViewport: 'iphone12mini',
+  },
+};


### PR DESCRIPTION
Added a story for cvi-ng-responsive-table with translations to reproduce an issue where header labels would not get translated on mobile