### PR TITLE
fix(ui): step navigation z-index below 40

### DIFF
--- a/libs/styles/src/lib/scss/settings/variables/_z-indexes.scss
+++ b/libs/styles/src/lib/scss/settings/variables/_z-indexes.scss
@@ -9,6 +9,10 @@ $cvi-z-indexes: (
   'tooltip': (
     'root',
   ),
+  'steps': (
+    '__scroll-button',
+    '__scroll-wrapper'
+  ),
   'modal': (
     '__backdrop',
     '__dialog'
@@ -18,9 +22,5 @@ $cvi-z-indexes: (
   ),
   'datepicker': (
     '__calender',
-  ),
-  'steps': (
-    '__scroll-button',
-    '__scroll-wrapper'
   ),
 );


### PR DESCRIPTION
Z-index of mobile step navigation needs to be under 40. Otherwise eesti.ee portal side menu stays behind step navigation